### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@ def deps do
     {:avrora, "~> 0.2"}
   ]
 end
-
-def applications do
-  [extra_applications: [:avrora]]
-end
 ```
 
 ## Configure


### PR DESCRIPTION
Mix automatically infers OTP applications required at runtime from the list of dependencies [since version 1.4](https://github.com/elixir-lang/elixir/blob/v1.4/CHANGELOG.md#application-inference).

Additionally, the key `extra_applications` is only needed to depend on stuff that ships with Elixir itself, like `logger`.