### PR TITLE
AVRO -> Avro

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 # Getting Started
 
-An Elixir library for convenient work with AVRO messages.
+An Elixir library for convenient work with Avro messages.
 It supports local schema files and Confluent® schema registry.
 
 Many thanks to [AvroTurf](https://github.com/dasch/avro_turf) Ruby gem for an inspiration.


### PR DESCRIPTION
If you check the [official documentation](https://avro.apache.org/docs/1.8.2/spec.html), "Avro" is spelled that way.