### PR TITLE
Add agnostic messages decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@ def deps do
     {:avrora, "~> 0.2"}
   ]
 end
-
-def applications do
-  [extra_applications: [:avrora]]
-end
 ```
 
 ## Configure

--- a/README.md
+++ b/README.md
@@ -120,4 +120,8 @@ message = <<8, 116, 120, 45, 49, 123, 20, 174, 71, 225, 250, 47, 64>>
 2. ~`Avrora.start/2` to support `extra_applications` in `mix.exs`~
 3. [Avro OCF](https://avro.apache.org/docs/1.8.1/spec.html#Object+Container+Files) encoding/decoding
 4. Add `Avrora.guess_type/1` for detecting encoding type used
-5. Add `type: pristine|registry|ocf` to `Avrora.encode/2` method
+5. Add `type: bare|csr|ocf` to `Avrora.encode/2` method
+```
+
+
+```

--- a/README.md
+++ b/README.md
@@ -116,12 +116,7 @@ message = <<8, 116, 120, 45, 49, 123, 20, 174, 71, 225, 250, 47, 64>>
 
 ## Roadmap
 
-1. ~Debug logging~
-2. ~`Avrora.start/2` to support `extra_applications` in `mix.exs`~
-3. [Avro OCF](https://avro.apache.org/docs/1.8.1/spec.html#Object+Container+Files) encoding/decoding
-4. Add `Avrora.guess_type/1` for detecting encoding type used
-5. Add `type: bare|csr|ocf` to `Avrora.encode/2` method
-```
-
-
-```
+- [x] Debug logging
+- [x] [Avro OCF](https://avro.apache.org/docs/1.8.1/spec.html#Object+Container+Files) decoding
+- [ ] [Avro OCF](https://avro.apache.org/docs/1.8.1/spec.html#Object+Container+Files) encoding
+- [ ] Add `format: bare|csr|ocf|auto` to `Avrora.encode/2` method

--- a/lib/avrora.ex
+++ b/lib/avrora.ex
@@ -1,13 +1,11 @@
 defmodule Avrora do
   @moduledoc File.read!("README.md")
 
-  use Application
   use Supervisor
 
   defdelegate encode(payload, opts), to: Avrora.Encoder
   defdelegate decode(payload, opts), to: Avrora.Encoder
 
-  def start(_type, _args), do: Supervisor.start_link([__MODULE__], strategy: :one_for_one)
   def start_link(opts \\ []), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
 
   def init(_state \\ []) do

--- a/lib/avrora.ex
+++ b/lib/avrora.ex
@@ -3,6 +3,7 @@ defmodule Avrora do
 
   use Supervisor
 
+  defdelegate decode(payload), to: Avrora.Encoder
   defdelegate encode(payload, opts), to: Avrora.Encoder
   defdelegate decode(payload, opts), to: Avrora.Encoder
 

--- a/lib/avrora/encoder.ex
+++ b/lib/avrora/encoder.ex
@@ -7,7 +7,8 @@ defmodule Avrora.Encoder do
   require Logger
   alias Avrora.{Mapper, Name, Resolver}
 
-  @registry_magic_byte <<0::size(8)>>
+  @registry_magic_bytes <<0::size(8)>>
+  @object_container_magic_bytes <<"Obj", 1>>
 
   @doc """
   Decodes given message with a schema eather loaded from the local file or from
@@ -32,7 +33,7 @@ defmodule Avrora.Encoder do
 
       {schema_name, body} =
         case payload do
-          <<@registry_magic_byte, <<version::size(32)>>, body::binary>> ->
+          <<@registry_magic_bytes, <<version::size(32)>>, body::binary>> ->
             {"#{schema_name.name}:#{version}", body}
 
           <<body::binary>> ->
@@ -69,7 +70,7 @@ defmodule Avrora.Encoder do
       body =
         if is_nil(avro.version),
           do: body,
-          else: <<@registry_magic_byte, <<avro.version::size(32)>>, body::binary>>
+          else: <<@registry_magic_bytes, <<avro.version::size(32)>>, body::binary>>
 
       {:ok, body}
     end

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,6 @@ defmodule Avrora.MixProject do
 
   def application do
     [
-      mod: {Avrora, []},
       extra_applications: [:logger, :inets, :ssl, :erlavro]
     ]
   end

--- a/test/avrora/encoder_test.exs
+++ b/test/avrora/encoder_test.exs
@@ -231,6 +231,18 @@ defmodule Avrora.EncoderTest do
 
       assert output =~ "with schema version is not allowed"
     end
+
+    test "when decoding with schema name OCF message" do
+      output =
+        capture_log(fn ->
+          {:ok, decoded} =
+            Encoder.decode(ocf_magic_message(), schema_name: "io.confluent.Payment")
+
+          assert decoded == [%{"id" => "00000000-0000-0000-0000-000000000000", "amount" => 15.99}]
+        end)
+
+      assert output =~ "given schema name will be ignored"
+    end
   end
 
   describe "encode/2" do

--- a/test/avrora/encoder_test.exs
+++ b/test/avrora/encoder_test.exs
@@ -6,6 +6,60 @@ defmodule Avrora.EncoderTest do
   import ExUnit.CaptureLog
   alias Avrora.Encoder
 
+  describe "decode/1" do
+    test "when payload was encoded with OCF magic byte" do
+      {:ok, decoded} = Encoder.decode(ocf_magic_message())
+      assert decoded == [%{"id" => "00000000-0000-0000-0000-000000000000", "amount" => 15.99}]
+    end
+
+    test "when payload was encoded with magic byte and registry is configured" do
+      Avrora.Storage.MemoryMock
+      |> expect(:get, fn key ->
+        assert key == 42
+
+        {:ok, nil}
+      end)
+      |> expect(:put, fn key, value ->
+        assert key == 42
+        assert value == schema_with_id()
+
+        {:ok, schema_with_id()}
+      end)
+
+      Avrora.Storage.RegistryMock
+      |> expect(:get, fn key ->
+        assert key == 42
+
+        {:ok, schema_with_id()}
+      end)
+
+      {:ok, decoded} = Encoder.decode(magic_message())
+      assert decoded == %{"id" => "00000000-0000-0000-0000-000000000000", "amount" => 15.99}
+    end
+
+    test "when payload was encoded with magic byte and registry is not configured" do
+      Avrora.Storage.MemoryMock
+      |> expect(:get, fn key ->
+        assert key == 42
+
+        {:ok, nil}
+      end)
+
+      Avrora.Storage.RegistryMock
+      |> expect(:get, fn key ->
+        assert key == 42
+
+        {:error, :unconfigured_registry_url}
+      end)
+
+      assert {:error, :unconfigured_registry_url} = Encoder.decode(magic_message())
+    end
+
+    test "when payload was encoded with no magic bytes" do
+      assert {:error, :undecodable} = Encoder.decode(message())
+    end
+  end
+
   describe "decode/2" do
     test "when payload was encoded without magic byte and registry is not configured" do
       Avrora.Storage.MemoryMock
@@ -334,10 +388,31 @@ defmodule Avrora.EncoderTest do
 
   defp raw_message, do: %{"id" => "00000000-0000-0000-0000-000000000000", "amount" => 15.99}
 
+  defp message do
+    <<72, 48, 48, 48, 48, 48, 48, 48, 48, 45, 48, 48, 48, 48, 45, 48, 48, 48, 48, 45, 48, 48, 48,
+      48, 45, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 123, 20, 174, 71, 225, 250, 47, 64>>
+  end
+
   defp magic_message do
     <<0, 0, 0, 0, 42, 72, 48, 48, 48, 48, 48, 48, 48, 48, 45, 48, 48, 48, 48, 45, 48, 48, 48, 48,
       45, 48, 48, 48, 48, 45, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 123, 20, 174, 71,
       225, 250, 47, 64>>
+  end
+
+  defp ocf_magic_message do
+    <<79, 98, 106, 1, 3, 204, 2, 20, 97, 118, 114, 111, 46, 99, 111, 100, 101, 99, 8, 110, 117,
+      108, 108, 22, 97, 118, 114, 111, 46, 115, 99, 104, 101, 109, 97, 144, 2, 123, 34, 110, 97,
+      109, 101, 115, 112, 97, 99, 101, 34, 58, 34, 105, 111, 46, 99, 111, 110, 102, 108, 117, 101,
+      110, 116, 34, 44, 34, 110, 97, 109, 101, 34, 58, 34, 80, 97, 121, 109, 101, 110, 116, 34,
+      44, 34, 116, 121, 112, 101, 34, 58, 34, 114, 101, 99, 111, 114, 100, 34, 44, 34, 102, 105,
+      101, 108, 100, 115, 34, 58, 91, 123, 34, 110, 97, 109, 101, 34, 58, 34, 105, 100, 34, 44,
+      34, 116, 121, 112, 101, 34, 58, 34, 115, 116, 114, 105, 110, 103, 34, 125, 44, 123, 34, 110,
+      97, 109, 101, 34, 58, 34, 97, 109, 111, 117, 110, 116, 34, 44, 34, 116, 121, 112, 101, 34,
+      58, 34, 100, 111, 117, 98, 108, 101, 34, 125, 93, 125, 0, 50, 8, 86, 136, 188, 182, 153, 91,
+      143, 129, 0, 45, 200, 112, 4, 192, 2, 90, 72, 48, 48, 48, 48, 48, 48, 48, 48, 45, 48, 48,
+      48, 48, 45, 48, 48, 48, 48, 45, 48, 48, 48, 48, 45, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48,
+      48, 48, 123, 20, 174, 71, 225, 250, 47, 64, 50, 8, 86, 136, 188, 182, 153, 91, 143, 129, 0,
+      45, 200, 112, 4, 192>>
   end
 
   defp not_magic_message do
@@ -358,6 +433,15 @@ defmodule Avrora.EncoderTest do
     %Avrora.Schema{
       id: nil,
       version: 42,
+      schema: erlavro_schema(),
+      raw_schema: raw_schema()
+    }
+  end
+
+  defp schema_with_id do
+    %Avrora.Schema{
+      id: 42,
+      version: nil,
       schema: erlavro_schema(),
       raw_schema: raw_schema()
     }


### PR DESCRIPTION
* New method `Avrora.decode/1` with magic bytes agnostic approach
* Handling [OCF](https://avro.apache.org/docs/1.8.1/spec.html#Object+Container+Files) messages
* Updated roadmap