### PR TITLE
Add optional format argumetn to encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ avrora-*.tar
 
 /priv/plts/*.plt
 /priv/plts/*.plt.hash
+
+TODO.org

--- a/lib/avrora.ex
+++ b/lib/avrora.ex
@@ -9,11 +9,12 @@ defmodule Avrora do
 
   def start_link(opts \\ []), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
 
+  @impl true
   def init(_state \\ []) do
     children = [
       Avrora.Storage.Memory
     ]
 
-    Supervisor.start_link(children, strategy: :one_for_one)
+    Supervisor.init(children, strategy: :one_for_one)
   end
 end

--- a/lib/avrora.ex
+++ b/lib/avrora.ex
@@ -7,7 +7,7 @@ defmodule Avrora do
   defdelegate encode(payload, opts), to: Avrora.Encoder
   defdelegate decode(payload, opts), to: Avrora.Encoder
 
-  def start_link(opts \\ []), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  def start_link(opts \\ []), do: Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
 
   @impl true
   def init(_state \\ []) do

--- a/lib/avrora/encoder.ex
+++ b/lib/avrora/encoder.ex
@@ -90,7 +90,7 @@ defmodule Avrora.Encoder do
             48, 48, 48, 123, 20, 174, 71, 225, 250, 47, 64>>}
   """
   @spec encode(map(), keyword(String.t())) :: {:ok, binary()} | {:error, term()}
-  def encode(payload, schema_name: schema_name),
+  def encode(payload, schema_name: schema_name) when is_map(payload),
     do: encode(payload, schema_name: schema_name, format: :guess)
 
   def encode(payload, schema_name: schema_name, format: format) when is_map(payload) do

--- a/lib/avrora/encoder.ex
+++ b/lib/avrora/encoder.ex
@@ -81,6 +81,13 @@ defmodule Avrora.Encoder do
   Encodes given message with a schema eather loaded from the local file or from
   the configured schema registry.
 
+  You can control formatting with a `:format` option, possible variants are:
+
+  * :guess - behaves like :ocf if can't behave like :registry (default)
+  * :ocf - embeds schema with Object Container File format
+  * :registry - embeds Confluent Schema Registry magic version
+  * :plain - gives nothing, but only encoded message
+
   ## Examples
 
       ...> payload = %{"id" => "00000000-0000-0000-0000-000000000000", "amount" => 15.99}
@@ -109,13 +116,13 @@ defmodule Avrora.Encoder do
             do: do_embed_schema(avro.schema, body),
             else: do_embed_version(avro.version, body)
 
-        :ocf ->
-          do_embed_schema(avro.schema, body)
-
         :registry ->
           if is_nil(avro.version),
             do: {:error, :invalid_schema_version},
             else: do_embed_version(avro.version, body)
+
+        :ocf ->
+          do_embed_schema(avro.schema, body)
 
         :plain ->
           {:ok, body}

--- a/lib/avrora/storage/registry.ex
+++ b/lib/avrora/storage/registry.ex
@@ -37,8 +37,6 @@ defmodule Avrora.Storage.Registry do
   @doc """
   Fetch a schema by a globally unique ID.
 
-  FIXME: Can't use a real docs with iex> because don't know how to make it work
-
   ## Examples
 
       ...> {:ok, avro} = Avrora.Storage.Registry.get(1)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Avrora.MixProject do
   def project do
     [
       app: :avrora,
-      version: "0.3.1",
+      version: "0.4.0",
       elixir: "~> 1.6",
       description: description(),
       package: package(),

--- a/test/avrora/encoder_test.exs
+++ b/test/avrora/encoder_test.exs
@@ -275,7 +275,7 @@ defmodule Avrora.EncoderTest do
       end)
 
       {:ok, encoded} = Encoder.encode(raw_message(), schema_name: "io.confluent.Payment")
-      assert is_ocf?(encoded)
+      assert is_ocf(encoded)
     end
 
     test "when registry is not configured, but format requires schema version" do
@@ -349,7 +349,7 @@ defmodule Avrora.EncoderTest do
       {:ok, encoded} =
         Encoder.encode(raw_message(), schema_name: "io.confluent.Payment", format: :ocf)
 
-      assert is_ocf?(encoded)
+      assert is_ocf(encoded)
     end
 
     test "when registry is configured, but schema not found" do
@@ -474,14 +474,16 @@ defmodule Avrora.EncoderTest do
     end
   end
 
-  defp is_ocf?(payload),
-    do: match?(payload, schema_header()) && match?(payload, not_magic_message())
+  defp is_ocf(payload) do
+    match?(
+      <<79, 98, 106, 1, _::size(1504), 72, 48, 48, 48, 48, 48, 48, 48, 48, 45, 48, 48, 48, 48, 45,
+        48, 48, 48, 48, 45, 48, 48, 48, 48, 45, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48,
+        123, 20, 174, 71, 225, 250, 47, 64, _::binary>>,
+      payload
+    )
+  end
 
   defp raw_message, do: %{"id" => "00000000-0000-0000-0000-000000000000", "amount" => 15.99}
-
-  defp schema_header do
-    <<79, 98, 106, 1>>
-  end
 
   defp magic_message do
     <<0, 0, 0, 0, 42, 72, 48, 48, 48, 48, 48, 48, 48, 48, 45, 48, 48, 48, 48, 45, 48, 48, 48, 48,


### PR DESCRIPTION
It will be possible to choose `format` style on encoding. Options will be:

* plain
* registry
* ocf
* guess (default)

Also, fixes supervision of the main module