### PR TITLE
Change resolver and memory storage rules

### DIFF
--- a/lib/avrora/encoder.ex
+++ b/lib/avrora/encoder.ex
@@ -75,7 +75,7 @@ defmodule Avrora.Encoder do
           do_decode(payload)
 
         _ ->
-          with {:ok, avro} <- Resolver.resolve_any(schema_id, schema_name.name),
+          with {:ok, avro} <- Resolver.resolve_any([schema_id, schema_name.name]),
                do: do_decode(avro.schema, body)
       end
     end

--- a/lib/avrora/resolver.ex
+++ b/lib/avrora/resolver.ex
@@ -29,7 +29,7 @@ defmodule Avrora.Resolver do
         {:ok, avro}
 
       _ ->
-        Logger.debug("fail to resolve schema by id `#{id}`, will fallback to name `#{name}`")
+        Logger.debug("fail to resolve by id `#{id}`, will fallback to name `#{name}`")
         resolve(name)
     end
   end

--- a/lib/avrora/resolver.ex
+++ b/lib/avrora/resolver.ex
@@ -4,7 +4,35 @@ defmodule Avrora.Resolver do
   memory and registry storage up to date.
   """
 
+  require Logger
   alias Avrora.{Config, Name}
+
+  @doc """
+  Resolves schema by either global ID or name (can contain version).
+
+  It will return first successful resolution result with order:
+
+    * Avrora.Resolver.resolve/1 when integer
+    * Avrora.Resolver.resolve/1 when binary
+
+  ## Examples
+
+      ...> {:ok, avro} = Avrora.Resolver.resolve_any(1, "io.confluent.Payment")
+      ...> {_, _, _, _, _, _, full_name, _} = avro.schema
+      ...> full_name
+      "io.confluent.Payment"
+  """
+  @spec resolve_any(integer(), String.t()) :: {:ok, Avrora.Schema.t()} | {:error, term()}
+  def resolve_any(id, name) do
+    case resolve(id) do
+      {:ok, avro} ->
+        {:ok, avro}
+
+      _ ->
+        Logger.debug("fail to resolve schema by id `#{id}`, will fallback to name `#{name}`")
+        resolve(name)
+    end
+  end
 
   @doc """
   Resolves schema by a global ID.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Avrora.MixProject do
   def project do
     [
       app: :avrora,
-      version: "0.4.0",
+      version: "0.5.0",
       elixir: "~> 1.6",
       description: description(),
       package: package(),

--- a/test/avrora/encoder_test.exs
+++ b/test/avrora/encoder_test.exs
@@ -101,23 +101,23 @@ defmodule Avrora.EncoderTest do
         {:ok, nil}
       end)
       |> expect(:put, fn key, value ->
-        assert key == "io.confluent.Payment"
-        assert value == schema_with_version()
+        assert key == 42
+        assert value == schema_with_id_and_version()
 
-        {:ok, schema_with_version()}
+        {:ok, schema_with_id_and_version()}
       end)
       |> expect(:put, fn key, value ->
-        assert key == "io.confluent.Payment:42"
-        assert value == schema_with_version()
+        assert key == "io.confluent.Payment:3"
+        assert value == schema_with_id_and_version()
 
-        {:ok, schema_with_version()}
+        {:ok, schema_with_id_and_version()}
       end)
 
       Avrora.Storage.RegistryMock
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, schema_with_version()}
+        {:ok, schema_with_id_and_version()}
       end)
 
       {:ok, decoded} = Encoder.decode(not_magic_message(), schema_name: "io.confluent.Payment")
@@ -127,7 +127,14 @@ defmodule Avrora.EncoderTest do
     test "when payload was encoded with magic byte and registry is not configured" do
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
-        assert key == "io.confluent.Payment:42"
+        assert key == 42
+
+        {:ok, nil}
+      end)
+
+      Avrora.Storage.MemoryMock
+      |> expect(:get, fn key ->
+        assert key == "io.confluent.Payment"
 
         {:ok, nil}
       end)
@@ -137,23 +144,22 @@ defmodule Avrora.EncoderTest do
 
         {:ok, schema()}
       end)
-      |> expect(:put, fn key, value ->
-        assert key == "io.confluent.Payment:42"
-        assert value == schema()
-
-        {:ok, schema_with_version()}
-      end)
 
       Avrora.Storage.RegistryMock
       |> expect(:get, fn key ->
-        assert key == "io.confluent.Payment:42"
+        assert key == 42
+
+        {:error, :unconfigured_registry_url}
+      end)
+      |> expect(:get, fn key ->
+        assert key == "io.confluent.Payment"
 
         {:error, :unconfigured_registry_url}
       end)
 
       Avrora.Storage.FileMock
       |> expect(:get, fn key ->
-        assert key == "io.confluent.Payment:42"
+        assert key == "io.confluent.Payment"
 
         {:ok, schema()}
       end)
@@ -165,28 +171,22 @@ defmodule Avrora.EncoderTest do
     test "when payload was encoded with magic byte and registry is configured" do
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
-        assert key == "io.confluent.Payment:42"
+        assert key == 42
 
         {:ok, nil}
       end)
       |> expect(:put, fn key, value ->
-        assert key == "io.confluent.Payment"
-        assert value == schema_with_version()
+        assert key == 42
+        assert value == schema_with_id()
 
-        {:ok, schema_with_version()}
-      end)
-      |> expect(:put, fn key, value ->
-        assert key == "io.confluent.Payment:42"
-        assert value == schema_with_version()
-
-        {:ok, schema_with_version()}
+        {:ok, schema_with_id_and_version()}
       end)
 
       Avrora.Storage.RegistryMock
       |> expect(:get, fn key ->
-        assert key == "io.confluent.Payment:42"
+        assert key == 42
 
-        {:ok, schema_with_version()}
+        {:ok, schema_with_id()}
       end)
 
       {:ok, decoded} = Encoder.decode(magic_message(), schema_name: "io.confluent.Payment")
@@ -229,7 +229,7 @@ defmodule Avrora.EncoderTest do
           assert decoded == %{"id" => "00000000-0000-0000-0000-000000000000", "amount" => 15.99}
         end)
 
-      assert output =~ "with schema version is not allowed"
+      assert output =~ "with schema version is not supported"
     end
 
     test "when decoding with schema name OCF message" do
@@ -320,23 +320,23 @@ defmodule Avrora.EncoderTest do
         {:ok, nil}
       end)
       |> expect(:put, fn key, value ->
-        assert key == "io.confluent.Payment"
-        assert value == schema_with_version()
+        assert key == 42
+        assert value == schema_with_id_and_version()
 
-        {:ok, schema_with_version()}
+        {:ok, schema_with_id_and_version()}
       end)
       |> expect(:put, fn key, value ->
-        assert key == "io.confluent.Payment:42"
-        assert value == schema_with_version()
+        assert key == "io.confluent.Payment:3"
+        assert value == schema_with_id_and_version()
 
-        {:ok, schema_with_version()}
+        {:ok, schema_with_id_and_version()}
       end)
 
       Avrora.Storage.RegistryMock
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, schema_with_version()}
+        {:ok, schema_with_id_and_version()}
       end)
 
       Avrora.Storage.FileMock
@@ -360,16 +360,16 @@ defmodule Avrora.EncoderTest do
         {:ok, nil}
       end)
       |> expect(:put, fn key, value ->
-        assert key == "io.confluent.Payment"
-        assert value == schema_with_version()
+        assert key == 42
+        assert value == schema_with_id_and_version()
 
-        {:ok, schema_with_version()}
+        {:ok, schema_with_id_and_version()}
       end)
       |> expect(:put, fn key, value ->
-        assert key == "io.confluent.Payment:42"
-        assert value == schema_with_version()
+        assert key == "io.confluent.Payment:3"
+        assert value == schema_with_id_and_version()
 
-        {:ok, schema_with_version()}
+        {:ok, schema_with_id_and_version()}
       end)
 
       Avrora.Storage.RegistryMock
@@ -382,7 +382,7 @@ defmodule Avrora.EncoderTest do
         assert key == "io.confluent.Payment"
         assert value == raw_schema()
 
-        {:ok, schema_with_version()}
+        {:ok, schema_with_id_and_version()}
       end)
 
       Avrora.Storage.FileMock
@@ -404,23 +404,23 @@ defmodule Avrora.EncoderTest do
         {:ok, nil}
       end)
       |> expect(:put, fn key, value ->
-        assert key == "io.confluent.Payment"
-        assert value == schema_with_version()
+        assert key == 42
+        assert value == schema_with_id_and_version()
 
-        {:ok, schema_with_version()}
+        {:ok, schema_with_id_and_version()}
       end)
       |> expect(:put, fn key, value ->
-        assert key == "io.confluent.Payment:42"
-        assert value == schema_with_version()
+        assert key == "io.confluent.Payment:3"
+        assert value == schema_with_id_and_version()
 
-        {:ok, schema_with_version()}
+        {:ok, schema_with_id_and_version()}
       end)
 
       Avrora.Storage.RegistryMock
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, schema_with_version()}
+        {:ok, schema_with_id_and_version()}
       end)
 
       Avrora.Storage.FileMock
@@ -470,7 +470,7 @@ defmodule Avrora.EncoderTest do
           assert not_magic_message() == encoded
         end)
 
-      assert output =~ "with schema version is not allowed"
+      assert output =~ "with schema version is not supported"
     end
   end
 
@@ -521,10 +521,10 @@ defmodule Avrora.EncoderTest do
     }
   end
 
-  defp schema_with_version do
+  defp schema_with_id_and_version do
     %Avrora.Schema{
-      id: nil,
-      version: 42,
+      id: 42,
+      version: 3,
       schema: erlavro_schema(),
       raw_schema: raw_schema()
     }

--- a/test/avrora/resolver_test.exs
+++ b/test/avrora/resolver_test.exs
@@ -3,7 +3,122 @@ defmodule Avrora.ResolverTest do
   doctest Avrora.Resolver
 
   import Mox
+  import ExUnit.CaptureLog
   alias Avrora.Resolver
+
+  describe "resolve_any/2" do
+    test "when registry is configured and schema was not found in memory, but registry" do
+      Avrora.Storage.MemoryMock
+      |> expect(:get, fn key ->
+        assert key == 1
+        {:ok, nil}
+      end)
+      |> expect(:put, fn key, value ->
+        assert key == 1
+        assert value == schema_with_id()
+        {:ok, value}
+      end)
+
+      Avrora.Storage.RegistryMock
+      |> expect(:get, fn key ->
+        assert key == 1
+        {:ok, schema_with_id()}
+      end)
+
+      {:ok, avro} = Resolver.resolve_any(1, "io.confluent.Payment")
+      {type, _, _, _, _, fields, full_name, _} = avro.schema
+
+      assert avro.id == 1
+      assert is_nil(avro.version)
+      assert type == :avro_record_type
+      assert full_name == "io.confluent.Payment"
+      assert length(fields) == 2
+    end
+
+    test "when registry is configured, but failing and schema was not found in a memory" do
+      Avrora.Storage.MemoryMock
+      |> expect(:get, fn key ->
+        assert key == 1
+        {:ok, nil}
+      end)
+      |> expect(:get, fn key ->
+        assert key == "io.confluent.Payment"
+        {:ok, nil}
+      end)
+
+      Avrora.Storage.RegistryMock
+      |> expect(:get, fn key ->
+        assert key == 1
+        {:error, :unknown_subject}
+      end)
+      |> expect(:get, fn key ->
+        assert key == "io.confluent.Payment"
+        {:error, :unknown_subject}
+      end)
+      |> expect(:put, fn key, value ->
+        assert key == "io.confluent.Payment"
+        assert value == raw_schema()
+        {:error, :unknown}
+      end)
+
+      Avrora.Storage.FileMock
+      |> expect(:get, fn key ->
+        assert key == "io.confluent.Payment"
+
+        {:ok, schema()}
+      end)
+
+      output =
+        capture_log(fn ->
+          assert {:error, :unknown} = Resolver.resolve_any(1, "io.confluent.Payment")
+        end)
+
+      assert output =~ "fail to resolve schema by id"
+    end
+
+    test "when registry is not configured and was not found in memory" do
+      Avrora.Storage.MemoryMock
+      |> expect(:get, fn key ->
+        assert key == 1
+        {:ok, nil}
+      end)
+      |> expect(:get, fn key ->
+        assert key == "io.confluent.Payment"
+        {:ok, nil}
+      end)
+      |> expect(:put, fn key, value ->
+        assert key == "io.confluent.Payment"
+        assert value == schema()
+        {:ok, value}
+      end)
+
+      Avrora.Storage.RegistryMock
+      |> expect(:get, fn key ->
+        assert key == 1
+        {:error, :unconfigured_registry_url}
+      end)
+      |> expect(:get, fn key ->
+        assert key == "io.confluent.Payment"
+        {:error, :unconfigured_registry_url}
+      end)
+
+      Avrora.Storage.FileMock
+      |> expect(:get, fn key ->
+        assert key == "io.confluent.Payment"
+
+        {:ok, schema()}
+      end)
+
+      {:ok, avro} = Resolver.resolve_any(1, "io.confluent.Payment")
+      {type, _, _, _, _, fields, full_name, _} = avro.schema
+
+      assert is_nil(avro.id)
+      assert is_nil(avro.version)
+      assert type == :avro_record_type
+      assert full_name == "io.confluent.Payment"
+      assert length(fields) == 2
+    end
+  end
 
   describe "resolve/1" do
     test "when global ID is given and it was found in a memory" do

--- a/test/avrora/resolver_test.exs
+++ b/test/avrora/resolver_test.exs
@@ -6,7 +6,7 @@ defmodule Avrora.ResolverTest do
   import ExUnit.CaptureLog
   alias Avrora.Resolver
 
-  describe "resolve_any/2" do
+  describe "resolve_any/1" do
     test "when registry is configured and schema was not found in memory, but registry" do
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->


### PR DESCRIPTION
Unfortunately, nightly programming is not that great on a quality side. I made a mistake by encoding and decoding schemas with registry magic thinking that a number after magic is a schema version, but the documentation explicitly said – schema id (i.e global schema id)

This PR will fix that mistake.

* Use `name:version` key when the schema is resolved by the registry
* Use `id` key when the schema is resolved by the registry (via global id)
* Use `name` key when the schema is resolved by the file name

