### PR TITLE
Add names cache and its eviction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ notifications:
   email: false
 
 elixir:
-  - 1.8.2
+  - 1.9.1
 
 otp_release:
-  - 21.1
+  - 22.0
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
       otp_release: "19.0"
     - elixir: "1.8"
       otp_release: "21.1"
+    - elixir: "1.9"
+      otp_release: "22.0"
       env:
         - DIALYZER=true
         - CREDO=true

--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ will be registered on encoding/decoding time.
 
 When a schema was resolved by the name in the schema registry, it is possible to
 cache the schema and assign it to that name, but if someone adds a new schema
-version you will never get it fetched again until you either clean the
-memory storage, or restart your application.
+version you will never get it fetched again until you either clean the memory
+storage or restart your application.
 
-To boost a performance of the schema resolution by name used a configuration
-option `names_cache_ttl`. It is the milliseconds to keep the
-resolved name schema cache in the memory. In you want to avoid names cache
-eviction you can set the value to `:infinity`.
+To boost the performance of the schema resolution by name use a configuration
+option `names_cache_ttl`. It is the milliseconds to keep the resolved name
+schema cache in the memory. If you want to avoid names cache eviction you can
+set the value to `:infinity`.
 
 :bulb: We can safely cache global id and versioned name resolution results
 because they will never change.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ memory storage, or restart your application.
 
 To boost a performance of the schema resolution by name used a configuration
 option `names_cache_ttl`. It is the milliseconds to keep the
-resolved name schema cache in the memory.
+resolved name schema cache in the memory. In you want to avoid names cache
+eviction you can set that value to `:infinity`.
 
 :bulb: We can safely cache global id and versioned name resolution results
 because they will never change.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To use Avrora with your projects, edit your `mix.exs` file and add it as a depen
 ```elixir
 def deps do
   [
-    {:avrora, "~> 0.2"}
+    {:avrora, "~> 0.5"}
   ]
 end
 ```
@@ -39,6 +39,7 @@ locally stored schemas. Add it in your `config/confix.exs`
 config :avrora,
   registry_url: "http://localhost:8081",      # default to `nil`
   schemas_path: Path.expand("./priv/schemas") # default to `./priv/schemas`
+  names_cache_ttl: :timer.minutes(5)          # default to `300_000` (milliseconds)
 ```
 
 If you will set `registry_url` to a non-`nil` value, then each time we need to find
@@ -47,6 +48,18 @@ schema registry and in case if it's not found we will do lookup in the local sch
 
 In addition schemas which was not found in the registry
 will be registered on encoding/decoding time.
+
+When a schema was resolved by the name in the schema registry, it is possible to
+cache the schema and assign it to that name, but if someone add a new version of
+that schema you will never get it fetched again until you either clean the
+memory storage, or restart your application.
+
+To boost a performance of the schema resolution by name used a configuration
+option `names_cache_ttl`. It is the milliseconds to keep the
+resolved name schema cache in the memory.
+
+:bulb: We can safely cache global id and versioned name resolution results
+because they will never change.
 
 ## Start new process manually
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To use Avrora with your projects, edit your `mix.exs` file and add it as a depen
 ```elixir
 def deps do
   [
-    {:avrora, "~> 0.5"}
+    {:avrora, "~> 0.6"}
   ]
 end
 ```
@@ -50,14 +50,14 @@ In addition schemas which was not found in the registry
 will be registered on encoding/decoding time.
 
 When a schema was resolved by the name in the schema registry, it is possible to
-cache the schema and assign it to that name, but if someone add a new version of
-that schema you will never get it fetched again until you either clean the
+cache the schema and assign it to that name, but if someone adds a new schema
+version you will never get it fetched again until you either clean the
 memory storage, or restart your application.
 
 To boost a performance of the schema resolution by name used a configuration
 option `names_cache_ttl`. It is the milliseconds to keep the
 resolved name schema cache in the memory. In you want to avoid names cache
-eviction you can set that value to `:infinity`.
+eviction you can set the value to `:infinity`.
 
 :bulb: We can safely cache global id and versioned name resolution results
 because they will never change.

--- a/config/config.exs
+++ b/config/config.exs
@@ -3,6 +3,6 @@ use Mix.Config
 config :avrora,
   schemas_path: Path.expand("./test/fixtures/schemas"),
   registry_url: nil,
-  names_cache_ttl: :timer.minutes(5)
+  names_cache_ttl: :timer.seconds(30)
 
 config :logger, :console, format: "$time $metadata[$level] $levelpad$message\n"

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,6 +2,7 @@ use Mix.Config
 
 config :avrora,
   schemas_path: Path.expand("./test/fixtures/schemas"),
-  registry_url: nil
+  registry_url: nil,
+  names_cache_ttl: :timer.minutes(5)
 
 config :logger, :console, format: "$time $metadata[$level] $levelpad$message\n"

--- a/lib/avrora/config.ex
+++ b/lib/avrora/config.ex
@@ -6,6 +6,7 @@ defmodule Avrora.Config do
 
       * `schemas_path` a path where all local schemas stored (default: ./priv/schemas)
       * `registry_url` a Confluent Schema Registry url (default: nil)
+      * `names_cache_ttl` a time to keep global schema names cached in millisecods (default: 300_000)
 
   ## Extra settings:
 
@@ -20,6 +21,9 @@ defmodule Avrora.Config do
 
   @doc false
   def registry_url, do: get_env(:registry_url, nil)
+
+  @doc false
+  def names_cache_ttl, do: get_env(:names_cache_ttl, :timer.minutes(5))
 
   @doc false
   def file_storage, do: get_env(:file_storage, Avrora.Storage.File)

--- a/lib/avrora/encoder.ex
+++ b/lib/avrora/encoder.ex
@@ -60,6 +60,7 @@ defmodule Avrora.Encoder do
       {schema_id, body} =
         case payload do
           <<@registry_magic_bytes, <<id::size(32)>>, body::binary>> ->
+            Logger.warn("message contains embeded global id, given schema name will be ignored")
             {id, body}
 
           <<@object_container_magic_bytes, _::binary>> ->

--- a/lib/avrora/encoder.ex
+++ b/lib/avrora/encoder.ex
@@ -116,13 +116,13 @@ defmodule Avrora.Encoder do
 
       case format do
         :guess ->
-          if is_nil(avro.version),
+          if is_nil(avro.id),
             do: do_embed_schema(avro.schema, body),
             else: do_embed_id(avro.id, body)
 
         :registry ->
-          if is_nil(avro.version),
-            do: {:error, :invalid_schema_version},
+          if is_nil(avro.id),
+            do: {:error, :invalid_schema_id},
             else: do_embed_id(avro.id, body)
 
         :ocf ->

--- a/lib/avrora/storage.ex
+++ b/lib/avrora/storage.ex
@@ -4,14 +4,33 @@ defmodule Avrora.Storage do
   name or a global ID and store a given schema under a specific name.
   """
 
-  @callback get(key :: String.t() | integer()) ::
-              {:ok, result :: nil | Avrora.Schema.t()} | {:error, reason :: term()}
-
-  @callback put(key :: String.t() | integer(), value :: String.t() | Avrora.Schema.t()) ::
-              {:ok, result :: Avrora.Schema.t()} | {:error, reason :: term()}
-
   @typedoc """
-  A possible schema indentifier
+  A possible schema indentifier.
   """
   @type schema_id :: String.t() | integer()
+
+  @callback get(key :: schema_id) ::
+              {:ok, result :: nil | Avrora.Schema.t()} | {:error, reason :: term()}
+
+  @callback put(key :: schema_id, value :: String.t() | Avrora.Schema.t()) ::
+              {:ok, result :: Avrora.Schema.t()} | {:error, reason :: term()}
+
+  defmodule Transient do
+    @moduledoc """
+    A type of storage which allows keys to be removed or expired.
+    """
+
+    alias Avrora.Storage
+
+    @typedoc """
+    A naive timestamp with a seconds precision.
+    """
+    @type timestamp :: timeout()
+
+    @callback delete(key :: Storage.schema_id()) ::
+                {:ok, result :: boolean()} | {:error, reason :: term()}
+
+    @callback expire(key :: Storage.schema_id(), ttl :: timeout()) ::
+                {:ok, timestamp :: timestamp()} | {:error, reason :: term()}
+  end
 end

--- a/lib/avrora/storage.ex
+++ b/lib/avrora/storage.ex
@@ -9,4 +9,9 @@ defmodule Avrora.Storage do
 
   @callback put(key :: String.t() | integer(), value :: String.t() | Avrora.Schema.t()) ::
               {:ok, result :: Avrora.Schema.t()} | {:error, reason :: term()}
+
+  @typedoc """
+  A possible schema indentifier
+  """
+  @type schema_id :: String.t() | integer()
 end

--- a/lib/avrora/storage/registry.ex
+++ b/lib/avrora/storage/registry.ex
@@ -29,7 +29,7 @@ defmodule Avrora.Storage.Registry do
          {:ok, version} <- Map.fetch(response, "version"),
          {:ok, schema} <- Map.fetch(response, "schema"),
          {:ok, schema} <- Schema.parse(schema) do
-      Logger.debug("obtaining schema #{schema_name.name} with version `#{version}`")
+      Logger.debug("obtaining schema `#{schema_name.name}` with version `#{version}`")
 
       {:ok, %{schema | id: id, version: version}}
     end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Avrora.MixProject do
   def project do
     [
       app: :avrora,
-      version: "0.5.2",
+      version: "0.6.0",
       elixir: "~> 1.6",
       description: description(),
       package: package(),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Avrora.MixProject do
   def project do
     [
       app: :avrora,
-      version: "0.5.1",
+      version: "0.5.2",
       elixir: "~> 1.6",
       description: description(),
       package: package(),

--- a/test/avrora/encoder_test.exs
+++ b/test/avrora/encoder_test.exs
@@ -6,6 +6,8 @@ defmodule Avrora.EncoderTest do
   import ExUnit.CaptureLog
   alias Avrora.Encoder
 
+  setup :verify_on_exit!
+
   describe "decode/1" do
     test "when payload was encoded with OCF magic byte" do
       {:ok, decoded} = Encoder.decode(ocf_magic_message())
@@ -23,7 +25,7 @@ defmodule Avrora.EncoderTest do
         assert key == 42
         assert value == schema_with_id()
 
-        {:ok, schema_with_id()}
+        {:ok, value}
       end)
 
       Avrora.Storage.RegistryMock
@@ -72,7 +74,7 @@ defmodule Avrora.EncoderTest do
         assert key == "io.confluent.Payment"
         assert value == schema()
 
-        {:ok, schema()}
+        {:ok, value}
       end)
 
       Avrora.Storage.RegistryMock
@@ -101,16 +103,28 @@ defmodule Avrora.EncoderTest do
         {:ok, nil}
       end)
       |> expect(:put, fn key, value ->
-        assert key == 42
-        assert value == schema_with_id_and_version()
-
-        {:ok, schema_with_id_and_version()}
-      end)
-      |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment:3"
         assert value == schema_with_id_and_version()
 
-        {:ok, schema_with_id_and_version()}
+        {:ok, value}
+      end)
+      |> expect(:put, fn key, value ->
+        assert key == "io.confluent.Payment"
+        assert value == schema_with_id_and_version()
+
+        {:ok, value}
+      end)
+      |> expect(:expire, fn key, ttl ->
+        assert key == "io.confluent.Payment"
+        assert ttl == :infinity
+
+        {:ok, :infinity}
+      end)
+      |> expect(:put, fn key, value ->
+        assert key == 42
+        assert value == schema_with_id_and_version()
+
+        {:ok, value}
       end)
 
       Avrora.Storage.RegistryMock
@@ -309,7 +323,7 @@ defmodule Avrora.EncoderTest do
       result =
         Encoder.encode(raw_message(), schema_name: "io.confluent.Payment", format: :registry)
 
-      assert {:error, :invalid_schema_version} = result
+      assert {:error, :invalid_schema_id} = result
     end
 
     test "when registry is configured and schema is found, but format is given explicitly" do
@@ -320,16 +334,28 @@ defmodule Avrora.EncoderTest do
         {:ok, nil}
       end)
       |> expect(:put, fn key, value ->
-        assert key == 42
-        assert value == schema_with_id_and_version()
-
-        {:ok, schema_with_id_and_version()}
-      end)
-      |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment:3"
         assert value == schema_with_id_and_version()
 
-        {:ok, schema_with_id_and_version()}
+        {:ok, value}
+      end)
+      |> expect(:put, fn key, value ->
+        assert key == "io.confluent.Payment"
+        assert value == schema_with_id_and_version()
+
+        {:ok, value}
+      end)
+      |> expect(:expire, fn key, ttl ->
+        assert key == "io.confluent.Payment"
+        assert ttl == :infinity
+
+        {:ok, :infinity}
+      end)
+      |> expect(:put, fn key, value ->
+        assert key == 42
+        assert value == schema_with_id_and_version()
+
+        {:ok, value}
       end)
 
       Avrora.Storage.RegistryMock
@@ -337,13 +363,6 @@ defmodule Avrora.EncoderTest do
         assert key == "io.confluent.Payment"
 
         {:ok, schema_with_id_and_version()}
-      end)
-
-      Avrora.Storage.FileMock
-      |> expect(:get, fn key ->
-        assert key == "io.confluent.Payment"
-
-        {:ok, schema()}
       end)
 
       {:ok, encoded} =
@@ -360,16 +379,22 @@ defmodule Avrora.EncoderTest do
         {:ok, nil}
       end)
       |> expect(:put, fn key, value ->
-        assert key == 42
-        assert value == schema_with_id_and_version()
+        assert key == "io.confluent.Payment"
+        assert value == schema_with_id()
 
-        {:ok, schema_with_id_and_version()}
+        {:ok, schema_with_id()}
+      end)
+      |> expect(:expire, fn key, ttl ->
+        assert key == "io.confluent.Payment"
+        assert ttl == :infinity
+
+        {:ok, :infinity}
       end)
       |> expect(:put, fn key, value ->
-        assert key == "io.confluent.Payment:3"
-        assert value == schema_with_id_and_version()
+        assert key == 42
+        assert value == schema_with_id()
 
-        {:ok, schema_with_id_and_version()}
+        {:ok, schema_with_id()}
       end)
 
       Avrora.Storage.RegistryMock
@@ -382,7 +407,7 @@ defmodule Avrora.EncoderTest do
         assert key == "io.confluent.Payment"
         assert value == raw_schema()
 
-        {:ok, schema_with_id_and_version()}
+        {:ok, schema_with_id()}
       end)
 
       Avrora.Storage.FileMock
@@ -404,16 +429,28 @@ defmodule Avrora.EncoderTest do
         {:ok, nil}
       end)
       |> expect(:put, fn key, value ->
-        assert key == 42
-        assert value == schema_with_id_and_version()
-
-        {:ok, schema_with_id_and_version()}
-      end)
-      |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment:3"
         assert value == schema_with_id_and_version()
 
-        {:ok, schema_with_id_and_version()}
+        {:ok, value}
+      end)
+      |> expect(:put, fn key, value ->
+        assert key == "io.confluent.Payment"
+        assert value == schema_with_id_and_version()
+
+        {:ok, value}
+      end)
+      |> expect(:expire, fn key, ttl ->
+        assert key == "io.confluent.Payment"
+        assert ttl == :infinity
+
+        {:ok, :infinity}
+      end)
+      |> expect(:put, fn key, value ->
+        assert key == 42
+        assert value == schema_with_id_and_version()
+
+        {:ok, value}
       end)
 
       Avrora.Storage.RegistryMock
@@ -421,13 +458,6 @@ defmodule Avrora.EncoderTest do
         assert key == "io.confluent.Payment"
 
         {:ok, schema_with_id_and_version()}
-      end)
-
-      Avrora.Storage.FileMock
-      |> expect(:get, fn key ->
-        assert key == "io.confluent.Payment"
-
-        {:ok, schema()}
       end)
 
       {:ok, encoded} = Encoder.encode(raw_message(), schema_name: "io.confluent.Payment")

--- a/test/avrora/encoder_test.exs
+++ b/test/avrora/encoder_test.exs
@@ -203,8 +203,13 @@ defmodule Avrora.EncoderTest do
         {:ok, schema_with_id()}
       end)
 
-      {:ok, decoded} = Encoder.decode(magic_message(), schema_name: "io.confluent.Payment")
-      assert decoded == %{"id" => "00000000-0000-0000-0000-000000000000", "amount" => 15.99}
+      output =
+        capture_log(fn ->
+          {:ok, decoded} = Encoder.decode(magic_message(), schema_name: "io.confluent.Payment")
+          assert decoded == %{"id" => "00000000-0000-0000-0000-000000000000", "amount" => 15.99}
+        end)
+
+      assert output =~ "message contains embeded global id, given schema name will be ignored"
     end
 
     test "when decoding with schema name containing version" do

--- a/test/avrora/encoder_test.exs
+++ b/test/avrora/encoder_test.exs
@@ -156,7 +156,7 @@ defmodule Avrora.EncoderTest do
         assert key == "io.confluent.Payment"
         assert value == schema()
 
-        {:ok, schema()}
+        {:ok, value}
       end)
 
       Avrora.Storage.RegistryMock
@@ -193,7 +193,7 @@ defmodule Avrora.EncoderTest do
         assert key == 42
         assert value == schema_with_id()
 
-        {:ok, schema_with_id_and_version()}
+        {:ok, value}
       end)
 
       Avrora.Storage.RegistryMock
@@ -218,7 +218,7 @@ defmodule Avrora.EncoderTest do
         assert key == "io.confluent.Payment"
         assert value == schema()
 
-        {:ok, schema()}
+        {:ok, value}
       end)
 
       Avrora.Storage.RegistryMock
@@ -271,7 +271,7 @@ defmodule Avrora.EncoderTest do
         assert key == "io.confluent.Payment"
         assert value == schema()
 
-        {:ok, schema()}
+        {:ok, value}
       end)
 
       Avrora.Storage.RegistryMock
@@ -303,7 +303,7 @@ defmodule Avrora.EncoderTest do
         assert key == "io.confluent.Payment"
         assert value == schema()
 
-        {:ok, schema()}
+        {:ok, value}
       end)
 
       Avrora.Storage.RegistryMock
@@ -382,7 +382,7 @@ defmodule Avrora.EncoderTest do
         assert key == "io.confluent.Payment"
         assert value == schema_with_id()
 
-        {:ok, schema_with_id()}
+        {:ok, value}
       end)
       |> expect(:expire, fn key, ttl ->
         assert key == "io.confluent.Payment"
@@ -394,7 +394,7 @@ defmodule Avrora.EncoderTest do
         assert key == 42
         assert value == schema_with_id()
 
-        {:ok, schema_with_id()}
+        {:ok, value}
       end)
 
       Avrora.Storage.RegistryMock
@@ -475,7 +475,7 @@ defmodule Avrora.EncoderTest do
         assert key == "io.confluent.Payment"
         assert value == schema()
 
-        {:ok, schema()}
+        {:ok, value}
       end)
 
       Avrora.Storage.RegistryMock

--- a/test/avrora/mapper_test.exs
+++ b/test/avrora/mapper_test.exs
@@ -6,8 +6,16 @@ defmodule Avrora.MapperTest do
 
   describe "to_map/1" do
     test "when a complex structure is given with many primitive types" do
-      transformed = Mapper.to_map([{"a", 1}, {"b", [[{"c", "3"}], [{"d", nil}]]}])
-      assert %{"a" => 1, "b" => [%{"c" => "3"}, %{"d" => nil}]} = transformed
+      transformed = Mapper.to_map(tuples())
+      assert %{"a" => 1, "b" => [%{"c" => "3"}, %{"d" => nil}], "x" => %{"y" => []}} = transformed
     end
+  end
+
+  defp tuples do
+    [
+      {"a", 1},
+      {"b", [[{"c", "3"}], [{"d", nil}]]},
+      {"x", [{"y", []}]}
+    ]
   end
 end

--- a/test/avrora/resolver_test.exs
+++ b/test/avrora/resolver_test.exs
@@ -6,6 +6,8 @@ defmodule Avrora.ResolverTest do
   import ExUnit.CaptureLog
   alias Avrora.Resolver
 
+  setup :verify_on_exit!
+
   describe "resolve_any/1" do
     test "when registry is configured and schema was not found in memory, but registry" do
       Avrora.Storage.MemoryMock
@@ -39,31 +41,31 @@ defmodule Avrora.ResolverTest do
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
         assert key == 1
+
         {:ok, nil}
       end)
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
-        {:ok, nil}
-      end)
-      |> expect(:put, fn key, value ->
-        assert key == "io.confluent.Payment"
-        assert value == schema()
+
         {:ok, nil}
       end)
 
       Avrora.Storage.RegistryMock
       |> expect(:get, fn key ->
         assert key == 1
+
         {:error, :unknown_subject}
       end)
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
+
         {:error, :unknown_subject}
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
         assert value == raw_schema()
-        {:error, :failure}
+
+        {:error, :unknown_error}
       end)
 
       Avrora.Storage.FileMock
@@ -75,7 +77,7 @@ defmodule Avrora.ResolverTest do
 
       output =
         capture_log(fn ->
-          assert {:error, :failure} = Resolver.resolve_any([1, "io.confluent.Payment"])
+          assert {:error, :unknown_error} = Resolver.resolve_any([1, "io.confluent.Payment"])
         end)
 
       assert output =~ "fail to resolve schema by identifier"
@@ -85,31 +87,31 @@ defmodule Avrora.ResolverTest do
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
         assert key == 1
+
         {:ok, nil}
       end)
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
+
         {:ok, nil}
       end)
 
       Avrora.Storage.RegistryMock
       |> expect(:get, fn key ->
         assert key == 1
+
         {:error, :unknown_subject}
       end)
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
+
         {:error, :unknown_subject}
-      end)
-      |> expect(:put, fn key, value ->
-        assert key == "io.confluent.Payment"
-        assert value == raw_schema()
-        {:error, :unknown_error}
       end)
 
       Avrora.Storage.FileMock
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
+
         {:error, :enoent}
       end)
 
@@ -235,13 +237,25 @@ defmodule Avrora.ResolverTest do
         {:ok, nil}
       end)
       |> expect(:put, fn key, value ->
-        assert key == 42
+        assert key == "io.confluent.Payment:3"
         assert value == schema_with_id_and_version()
 
         {:ok, value}
       end)
       |> expect(:put, fn key, value ->
-        assert key == "io.confluent.Payment:3"
+        assert key == "io.confluent.Payment"
+        assert value == schema_with_id_and_version()
+
+        {:ok, value}
+      end)
+      |> expect(:expire, fn key, ttl ->
+        assert key == "io.confluent.Payment"
+        assert ttl == :infinity
+
+        {:ok, :infinity}
+      end)
+      |> expect(:put, fn key, value ->
+        assert key == 42
         assert value == schema_with_id_and_version()
 
         {:ok, value}
@@ -270,6 +284,18 @@ defmodule Avrora.ResolverTest do
         assert key == "io.confluent.Payment"
 
         {:ok, nil}
+      end)
+      |> expect(:put, fn key, value ->
+        assert key == "io.confluent.Payment"
+        assert value == schema_with_id()
+
+        {:ok, value}
+      end)
+      |> expect(:expire, fn key, ttl ->
+        assert key == "io.confluent.Payment"
+        assert ttl == :infinity
+
+        {:ok, :infinity}
       end)
       |> expect(:put, fn key, value ->
         assert key == 1
@@ -368,6 +394,7 @@ defmodule Avrora.ResolverTest do
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment:3"
+
         {:ok, nil}
       end)
       |> expect(:put, fn key, value ->
@@ -380,12 +407,14 @@ defmodule Avrora.ResolverTest do
       Avrora.Storage.RegistryMock
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment:3"
+
         {:error, :unconfigured_registry_url}
       end)
 
       Avrora.Storage.FileMock
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment:3"
+
         {:ok, schema()}
       end)
 
@@ -394,6 +423,55 @@ defmodule Avrora.ResolverTest do
 
       assert is_nil(avro.id)
       assert is_nil(avro.version)
+      assert type == :avro_record_type
+      assert full_name == "io.confluent.Payment"
+      assert length(fields) == 2
+    end
+
+    test "when schema name with version is given and it was not found in a memory, but registry" do
+      Avrora.Storage.MemoryMock
+      |> expect(:get, fn key ->
+        assert key == "io.confluent.Payment:3"
+
+        {:ok, nil}
+      end)
+      |> expect(:put, fn key, value ->
+        assert key == "io.confluent.Payment:3"
+        assert value == schema_with_id_and_version()
+
+        {:ok, value}
+      end)
+      |> expect(:put, fn key, value ->
+        assert key == "io.confluent.Payment"
+        assert value == schema_with_id_and_version()
+
+        {:ok, value}
+      end)
+      |> expect(:expire, fn key, ttl ->
+        assert key == "io.confluent.Payment"
+        assert ttl == :infinity
+
+        {:ok, :infinity}
+      end)
+      |> expect(:put, fn key, value ->
+        assert key == 42
+        assert value == schema_with_id_and_version()
+
+        {:ok, value}
+      end)
+
+      Avrora.Storage.RegistryMock
+      |> expect(:get, fn key ->
+        assert key == "io.confluent.Payment:3"
+
+        {:ok, schema_with_id_and_version()}
+      end)
+
+      {:ok, avro} = Resolver.resolve("io.confluent.Payment:3")
+      {type, _, _, _, _, fields, full_name, _} = avro.schema
+
+      assert avro.id == 42
+      assert avro.version == 3
       assert type == :avro_record_type
       assert full_name == "io.confluent.Payment"
       assert length(fields) == 2

--- a/test/avrora/resolver_test.exs
+++ b/test/avrora/resolver_test.exs
@@ -13,17 +13,20 @@ defmodule Avrora.ResolverTest do
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
         assert key == 1
+
         {:ok, nil}
       end)
       |> expect(:put, fn key, value ->
         assert key == 1
         assert value == schema_with_id()
+
         {:ok, value}
       end)
 
       Avrora.Storage.RegistryMock
       |> expect(:get, fn key ->
         assert key == 1
+
         {:ok, schema_with_id()}
       end)
 
@@ -127,25 +130,30 @@ defmodule Avrora.ResolverTest do
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
         assert key == 1
+
         {:ok, nil}
       end)
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
+
         {:ok, nil}
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
         assert value == schema()
+
         {:ok, value}
       end)
 
       Avrora.Storage.RegistryMock
       |> expect(:get, fn key ->
         assert key == 1
+
         {:error, :unconfigured_registry_url}
       end)
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
+
         {:error, :unconfigured_registry_url}
       end)
 
@@ -172,6 +180,7 @@ defmodule Avrora.ResolverTest do
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
         assert key == 1
+
         {:ok, schema_with_id()}
       end)
 
@@ -189,17 +198,20 @@ defmodule Avrora.ResolverTest do
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
         assert key == 1
+
         {:ok, nil}
       end)
       |> expect(:put, fn key, value ->
         assert key == 1
         assert value == schema_with_id()
+
         {:ok, value}
       end)
 
       Avrora.Storage.RegistryMock
       |> expect(:get, fn key ->
         assert key == 1
+
         {:ok, schema_with_id()}
       end)
 
@@ -217,12 +229,14 @@ defmodule Avrora.ResolverTest do
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
         assert key == 1
+
         {:ok, nil}
       end)
 
       Avrora.Storage.RegistryMock
       |> expect(:get, fn key ->
         assert key == 1
+
         {:error, :unknown_subject}
       end)
 

--- a/test/avrora/storage/memory_test.exs
+++ b/test/avrora/storage/memory_test.exs
@@ -38,8 +38,45 @@ defmodule Avrora.Storage.MemoryTest do
     end
   end
 
+  describe "expire/3" do
+    test "when key already exists", %{schema_storage: pid} do
+      {:ok, _} = put(pid, "my-key-to-expire", schema())
+      {:ok, _} = expire(pid, "my-key-to-expire", 100)
+
+      assert get(pid, "my-key-to-expire") == {:ok, schema()}
+      Process.sleep(100)
+      assert get(pid, "my-key-to-expire") == {:ok, nil}
+    end
+
+    test "when key does not exist", %{schema_storage: pid} do
+      {:ok, _} = expire(pid, "my-key-to-expire", 100)
+
+      assert get(pid, "my-key-to-expire") == {:ok, nil}
+      Process.sleep(100)
+      assert get(pid, "my-key-to-expire") == {:ok, nil}
+    end
+  end
+
+  describe "delete/2" do
+    test "when key already exists", %{schema_storage: pid} do
+      {:ok, _} = put(pid, "my-key-to-delete", schema())
+
+      assert get(pid, "my-key-to-delete") == {:ok, schema()}
+      assert {:ok, true} = delete(pid, "my-key-to-delete")
+      assert get(pid, "my-key-to-delete") == {:ok, nil}
+    end
+
+    test "when key does not exist", %{schema_storage: pid} do
+      assert get(pid, "my-key-to-delete") == {:ok, nil}
+      assert {:ok, true} = delete(pid, "my-key-to-delete")
+      assert get(pid, "my-key-to-delete") == {:ok, nil}
+    end
+  end
+
   defp get(pid, key), do: Memory.get(pid, key)
   defp put(pid, key, value), do: Memory.put(pid, key, value)
+  defp delete(pid, key), do: Memory.delete(pid, key)
+  defp expire(pid, key, ttl), do: Memory.expire(pid, key, ttl)
 
   defp schema,
     do: %Avrora.Schema{

--- a/test/avrora/storage/memory_test.exs
+++ b/test/avrora/storage/memory_test.exs
@@ -41,10 +41,10 @@ defmodule Avrora.Storage.MemoryTest do
   describe "expire/3" do
     test "when key already exists", %{schema_storage: pid} do
       {:ok, _} = put(pid, "my-key-to-expire", schema())
-      {:ok, _} = expire(pid, "my-key-to-expire", 100)
+      {:ok, _} = expire(pid, "my-key-to-expire", 200)
 
       assert get(pid, "my-key-to-expire") == {:ok, schema()}
-      Process.sleep(100)
+      Process.sleep(200)
       assert get(pid, "my-key-to-expire") == {:ok, nil}
     end
 

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -1,4 +1,4 @@
 Mox.defmock(Avrora.HTTPClientMock, for: Avrora.HTTPClient)
 Mox.defmock(Avrora.Storage.FileMock, for: Avrora.Storage)
-Mox.defmock(Avrora.Storage.MemoryMock, for: Avrora.Storage)
+Mox.defmock(Avrora.Storage.MemoryMock, for: [Avrora.Storage, Avrora.Storage.Transient])
 Mox.defmock(Avrora.Storage.RegistryMock, for: Avrora.Storage)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,5 +5,6 @@ Application.put_env(:avrora, :registry_storage, Avrora.Storage.RegistryMock)
 
 Application.put_env(:avrora, :registry_url, "http://reg.loc")
 Application.put_env(:avrora, :schemas_path, Path.expand("./test/fixtures/schemas"))
+Application.put_env(:avrora, :names_cache_ttl, :infinity)
 
-ExUnit.start()
+ExUnit.start(capture_log: true)


### PR DESCRIPTION
It's not flexible to cache schema resolved by the name with a key equal to its `name`. But it will drastically speed up the resolution process.

But behind the name without the version, we mind `latest`. Unfortunately, each schema update in the schema registry will update `latest` schema value. Let's cache it, but for a short period of time.

```elixir
config :avrora, names_cache_ttl: :timer.minutes(10)
```