### PR TITLE
Fix schemas with types references

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,6 +1,6 @@
 [
   # NOTE: This code doesn't pass dialyxir because of the opaque types of erlavro functions.
-  #       The fix of dialyxir requere to silence too much functions.
+  #       The fix of dialyxir requires to silence too much functions and that's sad.
   #       https://github.com/klarna/erlavro/blob/3dcb4a90af88bfe297ca60781265fbba025db48d/src/avro_binary_encoder.erl#L87-L88
   {"lib/avrora/encoder.ex", :call_without_opaque},
   {"lib/avrora/encoder.ex", :pattern_match, 118},

--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,0 +1,9 @@
+[
+  # NOTE: This code doesn't pass dialyxir because of the opaque types of erlavro functions.
+  #       The fix of dialyxir requere to silence too much functions.
+  #       https://github.com/klarna/erlavro/blob/3dcb4a90af88bfe297ca60781265fbba025db48d/src/avro_binary_encoder.erl#L87-L88
+  {"lib/avrora/encoder.ex", :call_without_opaque},
+  {"lib/avrora/encoder.ex", :pattern_match, 118},
+  {"lib/avrora/encoder.ex", :unused_fun, 185},
+  {"lib/avrora/encoder.ex", :unused_fun, 191}
+]

--- a/README.md
+++ b/README.md
@@ -124,17 +124,17 @@ message = %{"id" => "tx-1", "amount" => 15.99}
   44, 123, 34, 110, 97, 109, 101, 34, 58, 34, 97, 109, 111, 117, 110, 116, 34,
   44, 34, 116, 121, 112, 101, 34, 58, 34, 100, 111, 117, 98, 108, 101, 34, 125,
   93, 125, 0, 138, 124, 66, 49, 157, 51, 242, 3, 33, 52, 161, 147, 221, 174,
-  114, 48, 2, 26, 8, 116, 120, 45, 49, 123, 20, 174, 71, 225, 250, 47, 64, 138, 
+  114, 48, 2, 26, 8, 116, 120, 45, 49, 123, 20, 174, 71, 225, 250, 47, 64, 138,
   124, 66, 49, 157, 51, 242, 3, 33, 52, 161, 147, 221, 174, 114, 48>>
 ```
 
 If you want to controll output format, you can provide `:format` option.
 Possible values are:
 
-* `:ocf` - embeds schema with [Object Container Files](https://avro.apache.org/docs/1.8.1/spec.html#Object+Container+Files) format
-* `:registry` - embeds Confluent [Schema Registry](https://docs.confluent.io/current/schema-registry/serializer-formatter.html#wire-format) magic version
-* `:plain` - only encode message with nothing embeded
-* `:guess` - fallbacks to `:ocf` if can't behave like `:registry` *(default)*
+- `:ocf` - embeds schema with [Object Container Files](https://avro.apache.org/docs/1.8.1/spec.html#Object+Container+Files) format
+- `:registry` - embeds Confluent [Schema Registry](https://docs.confluent.io/current/schema-registry/serializer-formatter.html#wire-format) magic version
+- `:plain` - only encode message with nothing embeded
+- `:guess` - fallbacks to `:ocf` if can't behave like `:registry` _(default)_
 
 ```elixir
 message = %{"id" => "tx-1", "amount" => 15.99}
@@ -143,7 +143,6 @@ message = %{"id" => "tx-1", "amount" => 15.99}
 {:ok, encoded} = Avrora.encode(message, schema_name: "io.confluent.Payment", format: :plain)
 <<8, 116, 120, 45, 49, 123, 20, 174, 71, 225, 250, 47, 64>>
 ```
-
 
 ### decode/2
 

--- a/lib/avrora/encoder.ex
+++ b/lib/avrora/encoder.ex
@@ -11,7 +11,7 @@ defmodule Avrora.Encoder do
   @object_container_magic_bytes <<"Obj", 1>>
   @decoder_options %{
     encoding: :avro_binary,
-    hook: &__MODULE__.__hook/4,
+    hook: &__MODULE__.__hook__/4,
     is_wrapped: true,
     map_type: :proplist,
     record_type: :map
@@ -147,7 +147,7 @@ defmodule Avrora.Encoder do
 
   # NOTE: `erlavro` allows to set a decoder hook, but we don't, at lease for now
   @doc false
-  def __hook(_type, _sub_name_or_id, data, decode_fun), do: decode_fun.(data)
+  def __hook__(_type, _sub_name_or_id, data, decode_fun), do: decode_fun.(data)
 
   defp do_decode(payload) do
     {_, _, decoded} = :avro_ocf.decode_binary(payload)

--- a/lib/avrora/schema.ex
+++ b/lib/avrora/schema.ex
@@ -4,12 +4,16 @@ defmodule Avrora.Schema do
   convinient use.
   """
 
-  defstruct [:id, :version, :schema, :raw_schema]
+  defstruct [:id, :version, :schema, :full_name, :lookup_table, :raw_schema]
 
   @type t :: %__MODULE__{
           id: nil | integer(),
           version: nil | integer(),
+          # FIXME: Deprecate field `schema` in favour of `schema_store`
           schema: :avro.record_type(),
+          full_name: String.t(),
+          lookup_table: reference(),
+          # FIXME: Rename field `raw_schema` to `json`
           raw_schema: String.t()
         }
 
@@ -27,13 +31,18 @@ defmodule Avrora.Schema do
   """
   @spec parse(String.t()) :: {:ok, t()} | {:error, term()}
   def parse(payload) when is_binary(payload) do
-    with {:ok, schema} <- do_parse(payload) do
+    with {:ok, schema} <- do_parse(payload),
+         {_, _, _, _, _, _, full_name, _} <- schema,
+         lookup_table <- :avro_schema_store.new(),
+         lookup_table <- :avro_schema_store.add_type(schema, lookup_table) do
       {
         :ok,
         %__MODULE__{
           id: nil,
           version: nil,
           schema: schema,
+          full_name: full_name,
+          lookup_table: lookup_table,
           raw_schema: payload
         }
       }

--- a/lib/avrora/schema.ex
+++ b/lib/avrora/schema.ex
@@ -44,8 +44,23 @@ defmodule Avrora.Schema do
     end
   end
 
-  def to_erlavro(self = %__MODULE__{}),
-    do: :avro_schema_store.lookup_type(self.full_name, self.lookup_table)
+  @doc """
+  Convert `Avrora.Schema` to erlavro definition. Definition will be retrieved
+  from the `lookup_table` of that schema.
+
+  ## Examples
+
+      iex> json = ~s({"namespace":"io.confluent","type":"record","name":"Payment","fields":[{"name":"id","type":"string"},{"name":"amount","type":"double"}]})
+      iex> {:ok, schema} = Avrora.Schema.parse(json)
+      iex> {:ok, {type, _, _, _, _, _, full_name, _}} = Avrora.Schema.to_erlavro(schema)
+      iex> full_name
+      "io.confluent.Payment"
+      iex> type
+      :avro_record_type
+  """
+  @spec parse(t()) :: {:ok, term()} | {:error, term()}
+  def to_erlavro(%__MODULE__{} = schema),
+    do: :avro_schema_store.lookup_type(schema.full_name, schema.lookup_table)
 
   defp do_parse(payload) do
     {:ok, :avro_json_decoder.decode_schema(payload)}

--- a/lib/avrora/storage.ex
+++ b/lib/avrora/storage.ex
@@ -12,7 +12,7 @@ defmodule Avrora.Storage do
   @callback get(key :: schema_id) ::
               {:ok, result :: nil | Avrora.Schema.t()} | {:error, reason :: term()}
 
-  @callback put(key :: schema_id, value :: String.t() | Avrora.Schema.t()) ::
+  @callback put(key :: schema_id, value :: Avrora.Schema.t()) ::
               {:ok, result :: Avrora.Schema.t()} | {:error, reason :: term()}
 
   defmodule Transient do

--- a/lib/avrora/storage/file.ex
+++ b/lib/avrora/storage/file.ex
@@ -31,10 +31,9 @@ defmodule Avrora.Storage.File do
 
   ## Examples
 
-      iex> {:ok, avro} = Avrora.Storage.File.get("io.confluent.examples.Payment")
-      iex> {type, _, _, _, _, _, full_name, _} = avro.schema
-      iex> full_name <> " of " <> type
-      "io.confluent.Payment of :avro_record_type"
+      iex> {:ok, schema} = Avrora.Storage.File.get("io.confluent.examples.Payment")
+      iex> schema.full_name
+      "io.confluent.Payment
   """
   def get(key) when is_binary(key) do
     with {:ok, schema_name} <- Name.parse(key),

--- a/lib/avrora/storage/file.ex
+++ b/lib/avrora/storage/file.ex
@@ -33,7 +33,7 @@ defmodule Avrora.Storage.File do
 
       iex> {:ok, schema} = Avrora.Storage.File.get("io.confluent.examples.Payment")
       iex> schema.full_name
-      "io.confluent.Payment
+      "io.confluent.Payment"
   """
   def get(key) when is_binary(key) do
     with {:ok, schema_name} <- Name.parse(key),

--- a/lib/avrora/storage/memory.ex
+++ b/lib/avrora/storage/memory.ex
@@ -92,9 +92,9 @@ defmodule Avrora.Storage.Memory do
 
   ## Examples
       iex> _ = Avrora.Storage.Memory.start_link()
-      iex> avro = %Avrora.Schema{id: nil, schema: [], raw_schema: "{}"}
-      iex> Avrora.Storage.Memory.put("my-key", avro)
-      {:ok, %Avrora.Schema{id: nil, schema: [], raw_schema: "{}"}}
+      iex> schema = %Avrora.Schema{id: nil, json: "{}"}
+      iex> Avrora.Storage.Memory.put("my-key", schema)
+      {:ok, %Avrora.Schema{id: nil, json: "{}"}}
   """
   @impl true
   def put(key, value), do: put(__MODULE__, key, value)
@@ -109,11 +109,11 @@ defmodule Avrora.Storage.Memory do
 
   ## Examples
       iex> _ = Avrora.Storage.Memory.start_link()
-      iex> avro = %Avrora.Schema{id: nil, schema: [], raw_schema: "{}"}
-      iex> Avrora.Storage.Memory.put("my-key", avro)
-      {:ok, %Avrora.Schema{id: nil, schema: [], raw_schema: "{}"}}
+      iex> schema = %Avrora.Schema{id: nil, json: "{}"}
+      iex> Avrora.Storage.Memory.put("my-key", schema)
+      {:ok, %Avrora.Schema{id: nil, json: "{}"}}
       iex> Avrora.Storage.Memory.get("my-key")
-      {:ok, %Avrora.Schema{id: nil, schema: [], raw_schema: "{}"}}
+      {:ok, %Avrora.Schema{id: nil, json: "{}"}}
       iex> Avrora.Storage.Memory.delete("my-key")
       {:ok, true}
       iex> Avrora.Storage.Memory.get("my-key")
@@ -132,12 +132,12 @@ defmodule Avrora.Storage.Memory do
 
   ## Examples
       iex> _ = Avrora.Storage.Memory.start_link()
-      iex> avro = %Avrora.Schema{id: nil, schema: [], raw_schema: "{}"}
-      iex> Avrora.Storage.Memory.put("my-key", avro)
-      {:ok, %Avrora.Schema{id: nil, schema: [], raw_schema: "{}"}}
+      iex> schema = %Avrora.Schema{id: nil, json: "{}"}
+      iex> Avrora.Storage.Memory.put("my-key", schema)
+      {:ok, %Avrora.Schema{id: nil, json: "{}"}}
       iex> {:ok, _} = Avrora.Storage.Memory.expire("my-key", 100)
       iex> Avrora.Storage.Memory.get("my-key")
-      {:ok, %Avrora.Schema{id: nil, schema: [], raw_schema: "{}"}}
+      {:ok, %Avrora.Schema{id: nil, json: "{}"}}
       iex> Process.sleep(100)
       iex> Avrora.Storage.Memory.get("my-key")
       {:ok, nil}

--- a/lib/avrora/storage/registry.ex
+++ b/lib/avrora/storage/registry.ex
@@ -16,10 +16,9 @@ defmodule Avrora.Storage.Registry do
 
   ## Examples
 
-      iex> {:ok, avro} = Avrora.Storage.Registry.get("io.confluent.Payment")
-      iex> {type, _, _, _, _, _, full_name, _} = avro.schema
-      iex> full_name <> " of " <> type
-      "io.confluent.Payment of :avro_record_type"
+      iex> {:ok, schema} = Avrora.Storage.Registry.get("io.confluent.Payment")
+      iex> schema.full_name
+      "io.confluent.Payment"
   """
   def get(key) when is_binary(key) do
     with {:ok, schema_name} <- Name.parse(key),
@@ -40,10 +39,9 @@ defmodule Avrora.Storage.Registry do
 
   ## Examples
 
-      ...> {:ok, avro} = Avrora.Storage.Registry.get(1)
-      ...> {type, _, _, _, _, _, full_name, _} = avro.schema
-      ...> full_name <> " of " <> type
-      "io.confluent.Payment of :avro_record_type"
+      ...> {:ok, schema} = Avrora.Storage.Registry.get(1)
+      ...> schema.full_name
+      "io.confluent.Payment"
   """
   def get(key) when is_integer(key) do
     with {:ok, response} <- http_client_get("schemas/ids/#{key}"),
@@ -61,10 +59,9 @@ defmodule Avrora.Storage.Registry do
   ## Examples
 
       iex> schema = ~s({"fields":[{"name":"id","type":"string"},{"name":"amount","type":"double"}],"name":"Payment","namespace":"io.confluent","type":"record"})
-      iex> {:ok, avro} = Avrora.Storage.Registry.put("io.confluent.examples.Payment", schema)
-      iex> {type, _, _, _, _, _, full_name, _} = avro.schema
-      iex> full_name <> " of " <> type
-      "io.confluent.Payment of :avro_record_type"
+      iex> {:ok, schema} = Avrora.Storage.Registry.put("io.confluent.examples.Payment", schema)
+      iex> schema.full_name
+      "io.confluent.Payment"
   """
   def put(key, value) when is_binary(key) and is_binary(value) do
     with {:ok, schema_name} <- Name.parse(key),

--- a/test/avrora/encoder_test.exs
+++ b/test/avrora/encoder_test.exs
@@ -10,12 +10,12 @@ defmodule Avrora.EncoderTest do
 
   describe "decode/1" do
     test "when payload was encoded with OCF magic byte" do
-      {:ok, decoded} = Encoder.decode(ocf_magic_message())
+      {:ok, decoded} = Encoder.decode(payment_ocf_message())
       assert decoded == [%{"id" => "00000000-0000-0000-0000-000000000000", "amount" => 15.99}]
     end
 
     test "when payload was encoded with magic byte and registry is configured" do
-      schema_with_id = schema_with_id()
+      payment_schema_with_id = payment_schema_with_id()
 
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
@@ -25,7 +25,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == 42
-        assert value == schema_with_id
+        assert value == payment_schema_with_id
 
         {:ok, value}
       end)
@@ -34,10 +34,10 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == 42
 
-        {:ok, schema_with_id}
+        {:ok, payment_schema_with_id}
       end)
 
-      {:ok, decoded} = Encoder.decode(magic_message())
+      {:ok, decoded} = Encoder.decode(payment_registry_message())
       assert decoded == %{"id" => "00000000-0000-0000-0000-000000000000", "amount" => 15.99}
     end
 
@@ -56,17 +56,17 @@ defmodule Avrora.EncoderTest do
         {:error, :unconfigured_registry_url}
       end)
 
-      assert {:error, :unconfigured_registry_url} = Encoder.decode(magic_message())
+      assert {:error, :unconfigured_registry_url} = Encoder.decode(payment_registry_message())
     end
 
     test "when payload was encoded with no magic bytes" do
-      assert {:error, :undecodable} = Encoder.decode(not_magic_message())
+      assert {:error, :undecodable} = Encoder.decode(payment_plain_message())
     end
   end
 
   describe "decode/2" do
     test "when payload was encoded without magic byte and registry is not configured" do
-      schema_without_id_and_version = schema_without_id_and_version()
+      payment_schema = payment_schema()
 
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
@@ -76,7 +76,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == schema_without_id_and_version
+        assert value == payment_schema
 
         {:ok, value}
       end)
@@ -92,15 +92,17 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, schema_without_id_and_version}
+        {:ok, payment_schema}
       end)
 
-      {:ok, decoded} = Encoder.decode(not_magic_message(), schema_name: "io.confluent.Payment")
+      {:ok, decoded} =
+        Encoder.decode(payment_plain_message(), schema_name: "io.confluent.Payment")
+
       assert decoded == %{"id" => "00000000-0000-0000-0000-000000000000", "amount" => 15.99}
     end
 
     test "when payload was encoded without magic byte and registry is configured" do
-      schema_with_id_and_version = schema_with_id_and_version()
+      payment_payment_schema_with_id_and_version = payment_payment_schema_with_id_and_version()
 
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
@@ -110,13 +112,13 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment:3"
-        assert value == schema_with_id_and_version
+        assert value == payment_payment_schema_with_id_and_version
 
         {:ok, value}
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == schema_with_id_and_version
+        assert value == payment_payment_schema_with_id_and_version
 
         {:ok, value}
       end)
@@ -128,7 +130,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == 42
-        assert value == schema_with_id_and_version
+        assert value == payment_payment_schema_with_id_and_version
 
         {:ok, value}
       end)
@@ -137,15 +139,17 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, schema_with_id_and_version}
+        {:ok, payment_payment_schema_with_id_and_version}
       end)
 
-      {:ok, decoded} = Encoder.decode(not_magic_message(), schema_name: "io.confluent.Payment")
+      {:ok, decoded} =
+        Encoder.decode(payment_plain_message(), schema_name: "io.confluent.Payment")
+
       assert decoded == %{"id" => "00000000-0000-0000-0000-000000000000", "amount" => 15.99}
     end
 
     test "when payload was encoded with magic byte and registry is not configured" do
-      schema_without_id_and_version = schema_without_id_and_version()
+      payment_schema = payment_schema()
 
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
@@ -162,7 +166,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == schema_without_id_and_version
+        assert value == payment_schema
 
         {:ok, value}
       end)
@@ -183,15 +187,17 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, schema_without_id_and_version}
+        {:ok, payment_schema}
       end)
 
-      {:ok, decoded} = Encoder.decode(magic_message(), schema_name: "io.confluent.Payment")
+      {:ok, decoded} =
+        Encoder.decode(payment_registry_message(), schema_name: "io.confluent.Payment")
+
       assert decoded == %{"id" => "00000000-0000-0000-0000-000000000000", "amount" => 15.99}
     end
 
     test "when payload was encoded with magic byte and registry is configured" do
-      schema_with_id = schema_with_id()
+      payment_schema_with_id = payment_schema_with_id()
 
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
@@ -201,7 +207,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == 42
-        assert value == schema_with_id
+        assert value == payment_schema_with_id
 
         {:ok, value}
       end)
@@ -210,12 +216,14 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == 42
 
-        {:ok, schema_with_id}
+        {:ok, payment_schema_with_id}
       end)
 
       output =
         capture_log(fn ->
-          {:ok, decoded} = Encoder.decode(magic_message(), schema_name: "io.confluent.Payment")
+          {:ok, decoded} =
+            Encoder.decode(payment_registry_message(), schema_name: "io.confluent.Payment")
+
           assert decoded == %{"id" => "00000000-0000-0000-0000-000000000000", "amount" => 15.99}
         end)
 
@@ -223,7 +231,7 @@ defmodule Avrora.EncoderTest do
     end
 
     test "when decoding with schema name containing version" do
-      schema_without_id_and_version = schema_without_id_and_version()
+      payment_schema = payment_schema()
 
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
@@ -233,7 +241,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == schema_without_id_and_version
+        assert value == payment_schema
 
         {:ok, value}
       end)
@@ -249,13 +257,13 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, schema_without_id_and_version}
+        {:ok, payment_schema}
       end)
 
       output =
         capture_log(fn ->
           {:ok, decoded} =
-            Encoder.decode(not_magic_message(), schema_name: "io.confluent.Payment:42")
+            Encoder.decode(payment_plain_message(), schema_name: "io.confluent.Payment:42")
 
           assert decoded == %{"id" => "00000000-0000-0000-0000-000000000000", "amount" => 15.99}
         end)
@@ -267,18 +275,57 @@ defmodule Avrora.EncoderTest do
       output =
         capture_log(fn ->
           {:ok, decoded} =
-            Encoder.decode(ocf_magic_message(), schema_name: "io.confluent.Payment")
+            Encoder.decode(payment_ocf_message(), schema_name: "io.confluent.Payment")
 
           assert decoded == [%{"id" => "00000000-0000-0000-0000-000000000000", "amount" => 15.99}]
         end)
 
       assert output =~ "given schema name will be ignored"
     end
+
+    test "when decoding plain message with type reference in it" do
+      messenger_schema = messenger_schema()
+
+      Avrora.Storage.MemoryMock
+      |> expect(:get, fn key ->
+        assert key == "io.confluent.Messenger"
+
+        {:ok, nil}
+      end)
+      |> expect(:put, fn key, value ->
+        assert key == "io.confluent.Messenger"
+        assert value == messenger_schema
+
+        {:ok, value}
+      end)
+
+      Avrora.Storage.RegistryMock
+      |> expect(:get, fn key ->
+        assert key == "io.confluent.Messenger"
+
+        {:error, :unconfigured_registry_url}
+      end)
+
+      Avrora.Storage.FileMock
+      |> expect(:get, fn key ->
+        assert key == "io.confluent.Messenger"
+
+        {:ok, messenger_schema}
+      end)
+
+      {:ok, decoded} =
+        Encoder.decode(messenger_plain_message(), schema_name: "io.confluent.Messenger")
+
+      assert decoded == %{
+               "inbox" => [%{"text" => "Hello world!"}],
+               "archive" => [%{"text" => "How are you?"}]
+             }
+    end
   end
 
   describe "encode/2" do
     test "when registry is not configured" do
-      schema_without_id_and_version = schema_without_id_and_version()
+      payment_schema = payment_schema()
 
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
@@ -288,7 +335,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == schema_without_id_and_version
+        assert value == payment_schema
 
         {:ok, value}
       end)
@@ -304,15 +351,15 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, schema_without_id_and_version}
+        {:ok, payment_schema}
       end)
 
-      {:ok, encoded} = Encoder.encode(raw_message(), schema_name: "io.confluent.Payment")
-      assert is_ocf(encoded)
+      {:ok, encoded} = Encoder.encode(payment_payload(), schema_name: "io.confluent.Payment")
+      assert is_payment_ocf(encoded)
     end
 
     test "when registry is not configured, but format requires schema version" do
-      schema_without_id_and_version = schema_without_id_and_version()
+      payment_schema = payment_schema()
 
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
@@ -322,7 +369,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == schema_without_id_and_version
+        assert value == payment_schema
 
         {:ok, value}
       end)
@@ -338,17 +385,17 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, schema_without_id_and_version}
+        {:ok, payment_schema}
       end)
 
       result =
-        Encoder.encode(raw_message(), schema_name: "io.confluent.Payment", format: :registry)
+        Encoder.encode(payment_payload(), schema_name: "io.confluent.Payment", format: :registry)
 
       assert {:error, :invalid_schema_id} = result
     end
 
     test "when registry is configured and schema is found, but format is given explicitly" do
-      schema_with_id_and_version = schema_with_id_and_version()
+      payment_payment_schema_with_id_and_version = payment_payment_schema_with_id_and_version()
 
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
@@ -358,13 +405,13 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment:3"
-        assert value == schema_with_id_and_version
+        assert value == payment_payment_schema_with_id_and_version
 
         {:ok, value}
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == schema_with_id_and_version
+        assert value == payment_payment_schema_with_id_and_version
 
         {:ok, value}
       end)
@@ -376,7 +423,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == 42
-        assert value == schema_with_id_and_version
+        assert value == payment_payment_schema_with_id_and_version
 
         {:ok, value}
       end)
@@ -385,18 +432,18 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, schema_with_id_and_version}
+        {:ok, payment_payment_schema_with_id_and_version}
       end)
 
       {:ok, encoded} =
-        Encoder.encode(raw_message(), schema_name: "io.confluent.Payment", format: :ocf)
+        Encoder.encode(payment_payload(), schema_name: "io.confluent.Payment", format: :ocf)
 
-      assert is_ocf(encoded)
+      assert is_payment_ocf(encoded)
     end
 
     test "when registry is configured, but schema not found" do
-      schema_with_id = schema_with_id()
-      schema_without_id_and_version = schema_without_id_and_version()
+      payment_schema_with_id = payment_schema_with_id()
+      payment_schema = payment_schema()
 
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
@@ -406,7 +453,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == schema_with_id
+        assert value == payment_schema_with_id
 
         {:ok, value}
       end)
@@ -418,7 +465,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == 42
-        assert value == schema_with_id
+        assert value == payment_schema_with_id
 
         {:ok, value}
       end)
@@ -431,24 +478,24 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == json_schema()
+        assert value == payment_json_schema()
 
-        {:ok, schema_with_id}
+        {:ok, payment_schema_with_id}
       end)
 
       Avrora.Storage.FileMock
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, schema_without_id_and_version}
+        {:ok, payment_schema}
       end)
 
-      {:ok, encoded} = Encoder.encode(raw_message(), schema_name: "io.confluent.Payment")
-      assert magic_message() == encoded
+      {:ok, encoded} = Encoder.encode(payment_payload(), schema_name: "io.confluent.Payment")
+      assert payment_registry_message() == encoded
     end
 
     test "when registry is configured and schema was found" do
-      schema_with_id_and_version = schema_with_id_and_version()
+      payment_payment_schema_with_id_and_version = payment_payment_schema_with_id_and_version()
 
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
@@ -458,13 +505,13 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment:3"
-        assert value == schema_with_id_and_version
+        assert value == payment_payment_schema_with_id_and_version
 
         {:ok, value}
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == schema_with_id_and_version
+        assert value == payment_payment_schema_with_id_and_version
 
         {:ok, value}
       end)
@@ -476,7 +523,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == 42
-        assert value == schema_with_id_and_version
+        assert value == payment_payment_schema_with_id_and_version
 
         {:ok, value}
       end)
@@ -485,15 +532,15 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, schema_with_id_and_version}
+        {:ok, payment_payment_schema_with_id_and_version}
       end)
 
-      {:ok, encoded} = Encoder.encode(raw_message(), schema_name: "io.confluent.Payment")
-      assert magic_message() == encoded
+      {:ok, encoded} = Encoder.encode(payment_payload(), schema_name: "io.confluent.Payment")
+      assert payment_registry_message() == encoded
     end
 
     test "when schema name provided with version" do
-      schema_without_id_and_version = schema_without_id_and_version()
+      payment_schema = payment_schema()
 
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
@@ -503,7 +550,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == schema_without_id_and_version
+        assert value == payment_schema
 
         {:ok, value}
       end)
@@ -519,22 +566,61 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, schema_without_id_and_version}
+        {:ok, payment_schema}
       end)
 
       output =
         capture_log(fn ->
           {:ok, encoded} =
-            Encoder.encode(raw_message(), schema_name: "io.confluent.Payment:42", format: :plain)
+            Encoder.encode(payment_payload(),
+              schema_name: "io.confluent.Payment:42",
+              format: :plain
+            )
 
-          assert not_magic_message() == encoded
+          assert payment_plain_message() == encoded
         end)
 
       assert output =~ "with schema version is not supported"
     end
+
+    test "when registry is not configured and payload contains type reference" do
+      messenger_schema = messenger_schema()
+
+      Avrora.Storage.MemoryMock
+      |> expect(:get, fn key ->
+        assert key == "io.confluent.Messenger"
+
+        {:ok, nil}
+      end)
+      |> expect(:put, fn key, value ->
+        assert key == "io.confluent.Messenger"
+        assert value == messenger_schema
+
+        {:ok, value}
+      end)
+
+      Avrora.Storage.RegistryMock
+      |> expect(:get, fn key ->
+        assert key == "io.confluent.Messenger"
+
+        {:error, :unconfigured_registry_url}
+      end)
+
+      Avrora.Storage.FileMock
+      |> expect(:get, fn key ->
+        assert key == "io.confluent.Messenger"
+
+        {:ok, messenger_schema}
+      end)
+
+      {:ok, encoded} =
+        Encoder.encode(messenger_payload(), schema_name: "io.confluent.Messenger", format: :plain)
+
+      assert encoded == messenger_plain_message()
+    end
   end
 
-  defp is_ocf(payload) do
+  defp is_payment_ocf(payload) do
     match?(
       <<79, 98, 106, 1, _::size(1504), 72, 48, 48, 48, 48, 48, 48, 48, 48, 45, 48, 48, 48, 48, 45,
         48, 48, 48, 48, 45, 48, 48, 48, 48, 45, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48,
@@ -543,15 +629,18 @@ defmodule Avrora.EncoderTest do
     )
   end
 
-  defp raw_message, do: %{"id" => "00000000-0000-0000-0000-000000000000", "amount" => 15.99}
+  defp payment_payload, do: %{"id" => "00000000-0000-0000-0000-000000000000", "amount" => 15.99}
 
-  defp magic_message do
+  defp messenger_payload,
+    do: %{"inbox" => [%{"text" => "Hello world!"}], "archive" => [%{"text" => "How are you?"}]}
+
+  defp payment_registry_message do
     <<0, 0, 0, 0, 42, 72, 48, 48, 48, 48, 48, 48, 48, 48, 45, 48, 48, 48, 48, 45, 48, 48, 48, 48,
       45, 48, 48, 48, 48, 45, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 123, 20, 174, 71,
       225, 250, 47, 64>>
   end
 
-  defp ocf_magic_message do
+  defp payment_ocf_message do
     <<79, 98, 106, 1, 3, 204, 2, 20, 97, 118, 114, 111, 46, 99, 111, 100, 101, 99, 8, 110, 117,
       108, 108, 22, 97, 118, 114, 111, 46, 115, 99, 104, 101, 109, 97, 144, 2, 123, 34, 110, 97,
       109, 101, 115, 112, 97, 99, 101, 34, 58, 34, 105, 111, 46, 99, 111, 110, 102, 108, 117, 101,
@@ -567,27 +656,41 @@ defmodule Avrora.EncoderTest do
       243, 64, 50, 180, 153, 105, 34>>
   end
 
-  defp not_magic_message do
+  defp payment_plain_message do
     <<72, 48, 48, 48, 48, 48, 48, 48, 48, 45, 48, 48, 48, 48, 45, 48, 48, 48, 48, 45, 48, 48, 48,
       48, 45, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 123, 20, 174, 71, 225, 250, 47, 64>>
   end
 
-  defp schema_without_id_and_version do
-    {:ok, schema} = Schema.parse(json_schema())
+  defp messenger_plain_message do
+    <<1, 26, 24, 72, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100, 33, 0, 1, 26, 24, 72, 111,
+      119, 32, 97, 114, 101, 32, 121, 111, 117, 63, 0>>
+  end
+
+  defp payment_schema do
+    {:ok, schema} = Schema.parse(payment_json_schema())
     %{schema | id: nil, version: nil}
   end
 
-  defp schema_with_id_and_version do
-    {:ok, schema} = Schema.parse(json_schema())
+  defp payment_payment_schema_with_id_and_version do
+    {:ok, schema} = Schema.parse(payment_json_schema())
     %{schema | id: 42, version: 3}
   end
 
-  defp schema_with_id do
-    {:ok, schema} = Schema.parse(json_schema())
+  defp payment_schema_with_id do
+    {:ok, schema} = Schema.parse(payment_json_schema())
     %{schema | id: 42, version: nil}
   end
 
-  defp json_schema do
+  defp messenger_schema do
+    {:ok, schema} = Schema.parse(messenger_json_schema())
+    %{schema | id: nil, version: nil}
+  end
+
+  defp messenger_json_schema do
+    ~s({"type":"record","name":"Messenger","namespace":"io.confluent","fields":[{"name":"inbox","type":{"type":"array","items":{"type":"record","name":"Message","fields":[{"name":"text","type":"string"}]}}},{"name":"archive","type":{"type":"array","items":"io.confluent.Message"}}]})
+  end
+
+  defp payment_json_schema do
     ~s({"namespace":"io.confluent","type":"record","name":"Payment","fields":[{"name":"id","type":"string"},{"name":"amount","type":"double"}]})
   end
 end

--- a/test/avrora/encoder_test.exs
+++ b/test/avrora/encoder_test.exs
@@ -15,6 +15,8 @@ defmodule Avrora.EncoderTest do
     end
 
     test "when payload was encoded with magic byte and registry is configured" do
+      schema_with_id = schema_with_id()
+
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
         assert key == 42
@@ -23,7 +25,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == 42
-        assert value == schema_with_id()
+        assert value == schema_with_id
 
         {:ok, value}
       end)
@@ -32,7 +34,7 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == 42
 
-        {:ok, schema_with_id()}
+        {:ok, schema_with_id}
       end)
 
       {:ok, decoded} = Encoder.decode(magic_message())
@@ -64,6 +66,8 @@ defmodule Avrora.EncoderTest do
 
   describe "decode/2" do
     test "when payload was encoded without magic byte and registry is not configured" do
+      schema = schema()
+
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
@@ -72,7 +76,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == schema()
+        assert value == schema
 
         {:ok, value}
       end)
@@ -88,7 +92,7 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, schema()}
+        {:ok, schema}
       end)
 
       {:ok, decoded} = Encoder.decode(not_magic_message(), schema_name: "io.confluent.Payment")
@@ -96,6 +100,8 @@ defmodule Avrora.EncoderTest do
     end
 
     test "when payload was encoded without magic byte and registry is configured" do
+      schema_with_id_and_version = schema_with_id_and_version()
+
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
@@ -104,13 +110,13 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment:3"
-        assert value == schema_with_id_and_version()
+        assert value == schema_with_id_and_version
 
         {:ok, value}
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == schema_with_id_and_version()
+        assert value == schema_with_id_and_version
 
         {:ok, value}
       end)
@@ -122,7 +128,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == 42
-        assert value == schema_with_id_and_version()
+        assert value == schema_with_id_and_version
 
         {:ok, value}
       end)
@@ -131,7 +137,7 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, schema_with_id_and_version()}
+        {:ok, schema_with_id_and_version}
       end)
 
       {:ok, decoded} = Encoder.decode(not_magic_message(), schema_name: "io.confluent.Payment")
@@ -139,6 +145,8 @@ defmodule Avrora.EncoderTest do
     end
 
     test "when payload was encoded with magic byte and registry is not configured" do
+      schema = schema()
+
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
         assert key == 42
@@ -154,7 +162,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == schema()
+        assert value == schema
 
         {:ok, value}
       end)
@@ -175,7 +183,7 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, schema()}
+        {:ok, schema}
       end)
 
       {:ok, decoded} = Encoder.decode(magic_message(), schema_name: "io.confluent.Payment")
@@ -183,6 +191,8 @@ defmodule Avrora.EncoderTest do
     end
 
     test "when payload was encoded with magic byte and registry is configured" do
+      schema_with_id = schema_with_id()
+
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
         assert key == 42
@@ -191,7 +201,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == 42
-        assert value == schema_with_id()
+        assert value == schema_with_id
 
         {:ok, value}
       end)
@@ -200,7 +210,7 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == 42
 
-        {:ok, schema_with_id()}
+        {:ok, schema_with_id}
       end)
 
       output =
@@ -213,6 +223,8 @@ defmodule Avrora.EncoderTest do
     end
 
     test "when decoding with schema name containing version" do
+      schema = schema()
+
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
@@ -221,7 +233,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == schema()
+        assert value == schema
 
         {:ok, value}
       end)
@@ -237,7 +249,7 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, schema()}
+        {:ok, schema}
       end)
 
       output =
@@ -266,6 +278,8 @@ defmodule Avrora.EncoderTest do
 
   describe "encode/2" do
     test "when registry is not configured" do
+      schema = schema()
+
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
@@ -274,7 +288,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == schema()
+        assert value == schema
 
         {:ok, value}
       end)
@@ -290,7 +304,7 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, schema()}
+        {:ok, schema}
       end)
 
       {:ok, encoded} = Encoder.encode(raw_message(), schema_name: "io.confluent.Payment")
@@ -298,6 +312,8 @@ defmodule Avrora.EncoderTest do
     end
 
     test "when registry is not configured, but format requires schema version" do
+      schema = schema()
+
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
@@ -306,7 +322,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == schema()
+        assert value == schema
 
         {:ok, value}
       end)
@@ -322,7 +338,7 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, schema()}
+        {:ok, schema}
       end)
 
       result =
@@ -332,6 +348,8 @@ defmodule Avrora.EncoderTest do
     end
 
     test "when registry is configured and schema is found, but format is given explicitly" do
+      schema_with_id_and_version = schema_with_id_and_version()
+
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
@@ -340,13 +358,13 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment:3"
-        assert value == schema_with_id_and_version()
+        assert value == schema_with_id_and_version
 
         {:ok, value}
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == schema_with_id_and_version()
+        assert value == schema_with_id_and_version
 
         {:ok, value}
       end)
@@ -358,7 +376,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == 42
-        assert value == schema_with_id_and_version()
+        assert value == schema_with_id_and_version
 
         {:ok, value}
       end)
@@ -367,7 +385,7 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, schema_with_id_and_version()}
+        {:ok, schema_with_id_and_version}
       end)
 
       {:ok, encoded} =
@@ -377,6 +395,8 @@ defmodule Avrora.EncoderTest do
     end
 
     test "when registry is configured, but schema not found" do
+      schema_with_id = schema_with_id()
+
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
@@ -385,7 +405,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == schema_with_id()
+        assert value == schema_with_id
 
         {:ok, value}
       end)
@@ -397,7 +417,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == 42
-        assert value == schema_with_id()
+        assert value == schema_with_id
 
         {:ok, value}
       end)
@@ -412,7 +432,7 @@ defmodule Avrora.EncoderTest do
         assert key == "io.confluent.Payment"
         assert value == raw_schema()
 
-        {:ok, schema_with_id()}
+        {:ok, schema_with_id}
       end)
 
       Avrora.Storage.FileMock
@@ -427,6 +447,8 @@ defmodule Avrora.EncoderTest do
     end
 
     test "when registry is configured and schema was found" do
+      schema_with_id_and_version = schema_with_id_and_version()
+
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
@@ -435,13 +457,13 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment:3"
-        assert value == schema_with_id_and_version()
+        assert value == schema_with_id_and_version
 
         {:ok, value}
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == schema_with_id_and_version()
+        assert value == schema_with_id_and_version
 
         {:ok, value}
       end)
@@ -453,7 +475,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == 42
-        assert value == schema_with_id_and_version()
+        assert value == schema_with_id_and_version
 
         {:ok, value}
       end)
@@ -462,7 +484,7 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, schema_with_id_and_version()}
+        {:ok, schema_with_id_and_version}
       end)
 
       {:ok, encoded} = Encoder.encode(raw_message(), schema_name: "io.confluent.Payment")
@@ -470,6 +492,8 @@ defmodule Avrora.EncoderTest do
     end
 
     test "when schema name provided with version" do
+      schema = schema()
+
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
@@ -478,7 +502,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == schema()
+        assert value == schema
 
         {:ok, value}
       end)
@@ -494,7 +518,7 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, schema()}
+        {:ok, schema}
       end)
 
       output =
@@ -548,27 +572,39 @@ defmodule Avrora.EncoderTest do
   end
 
   defp schema do
+    lookup_table = :avro_schema_store.new()
+
     %Avrora.Schema{
       id: nil,
       version: nil,
+      full_name: "io.confluent.Payment",
+      lookup_table: :avro_schema_store.add_type(erlavro_schema(), lookup_table),
       schema: erlavro_schema(),
       raw_schema: raw_schema()
     }
   end
 
   defp schema_with_id_and_version do
+    lookup_table = :avro_schema_store.new()
+
     %Avrora.Schema{
       id: 42,
       version: 3,
+      full_name: "io.confluent.Payment",
+      lookup_table: :avro_schema_store.add_type(erlavro_schema(), lookup_table),
       schema: erlavro_schema(),
       raw_schema: raw_schema()
     }
   end
 
   defp schema_with_id do
+    lookup_table = :avro_schema_store.new()
+
     %Avrora.Schema{
       id: 42,
       version: nil,
+      full_name: "io.confluent.Payment",
+      lookup_table: :avro_schema_store.add_type(erlavro_schema(), lookup_table),
       schema: erlavro_schema(),
       raw_schema: raw_schema()
     }

--- a/test/avrora/encoder_test.exs
+++ b/test/avrora/encoder_test.exs
@@ -4,7 +4,7 @@ defmodule Avrora.EncoderTest do
 
   import Mox
   import ExUnit.CaptureLog
-  alias Avrora.Encoder
+  alias Avrora.{Encoder, Schema}
 
   setup :verify_on_exit!
 
@@ -66,7 +66,7 @@ defmodule Avrora.EncoderTest do
 
   describe "decode/2" do
     test "when payload was encoded without magic byte and registry is not configured" do
-      schema = schema()
+      schema_without_id_and_version = schema_without_id_and_version()
 
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
@@ -76,7 +76,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == schema
+        assert value == schema_without_id_and_version
 
         {:ok, value}
       end)
@@ -92,7 +92,7 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, schema}
+        {:ok, schema_without_id_and_version}
       end)
 
       {:ok, decoded} = Encoder.decode(not_magic_message(), schema_name: "io.confluent.Payment")
@@ -145,7 +145,7 @@ defmodule Avrora.EncoderTest do
     end
 
     test "when payload was encoded with magic byte and registry is not configured" do
-      schema = schema()
+      schema_without_id_and_version = schema_without_id_and_version()
 
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
@@ -162,7 +162,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == schema
+        assert value == schema_without_id_and_version
 
         {:ok, value}
       end)
@@ -183,7 +183,7 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, schema}
+        {:ok, schema_without_id_and_version}
       end)
 
       {:ok, decoded} = Encoder.decode(magic_message(), schema_name: "io.confluent.Payment")
@@ -223,7 +223,7 @@ defmodule Avrora.EncoderTest do
     end
 
     test "when decoding with schema name containing version" do
-      schema = schema()
+      schema_without_id_and_version = schema_without_id_and_version()
 
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
@@ -233,7 +233,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == schema
+        assert value == schema_without_id_and_version
 
         {:ok, value}
       end)
@@ -249,7 +249,7 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, schema}
+        {:ok, schema_without_id_and_version}
       end)
 
       output =
@@ -278,7 +278,7 @@ defmodule Avrora.EncoderTest do
 
   describe "encode/2" do
     test "when registry is not configured" do
-      schema = schema()
+      schema_without_id_and_version = schema_without_id_and_version()
 
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
@@ -288,7 +288,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == schema
+        assert value == schema_without_id_and_version
 
         {:ok, value}
       end)
@@ -304,7 +304,7 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, schema}
+        {:ok, schema_without_id_and_version}
       end)
 
       {:ok, encoded} = Encoder.encode(raw_message(), schema_name: "io.confluent.Payment")
@@ -312,7 +312,7 @@ defmodule Avrora.EncoderTest do
     end
 
     test "when registry is not configured, but format requires schema version" do
-      schema = schema()
+      schema_without_id_and_version = schema_without_id_and_version()
 
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
@@ -322,7 +322,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == schema
+        assert value == schema_without_id_and_version
 
         {:ok, value}
       end)
@@ -338,7 +338,7 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, schema}
+        {:ok, schema_without_id_and_version}
       end)
 
       result =
@@ -396,6 +396,7 @@ defmodule Avrora.EncoderTest do
 
     test "when registry is configured, but schema not found" do
       schema_with_id = schema_with_id()
+      schema_without_id_and_version = schema_without_id_and_version()
 
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
@@ -430,7 +431,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == raw_schema()
+        assert value == json_schema()
 
         {:ok, schema_with_id}
       end)
@@ -439,7 +440,7 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, schema()}
+        {:ok, schema_without_id_and_version}
       end)
 
       {:ok, encoded} = Encoder.encode(raw_message(), schema_name: "io.confluent.Payment")
@@ -492,7 +493,7 @@ defmodule Avrora.EncoderTest do
     end
 
     test "when schema name provided with version" do
-      schema = schema()
+      schema_without_id_and_version = schema_without_id_and_version()
 
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
@@ -502,7 +503,7 @@ defmodule Avrora.EncoderTest do
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == schema
+        assert value == schema_without_id_and_version
 
         {:ok, value}
       end)
@@ -518,7 +519,7 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, schema}
+        {:ok, schema_without_id_and_version}
       end)
 
       output =
@@ -571,50 +572,22 @@ defmodule Avrora.EncoderTest do
       48, 45, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 123, 20, 174, 71, 225, 250, 47, 64>>
   end
 
-  defp schema do
-    lookup_table = :avro_schema_store.new()
-
-    %Avrora.Schema{
-      id: nil,
-      version: nil,
-      full_name: "io.confluent.Payment",
-      lookup_table: :avro_schema_store.add_type(erlavro_schema(), lookup_table),
-      schema: erlavro_schema(),
-      raw_schema: raw_schema()
-    }
+  defp schema_without_id_and_version do
+    {:ok, schema} = Schema.parse(json_schema())
+    %{schema | id: nil, version: nil}
   end
 
   defp schema_with_id_and_version do
-    lookup_table = :avro_schema_store.new()
-
-    %Avrora.Schema{
-      id: 42,
-      version: 3,
-      full_name: "io.confluent.Payment",
-      lookup_table: :avro_schema_store.add_type(erlavro_schema(), lookup_table),
-      schema: erlavro_schema(),
-      raw_schema: raw_schema()
-    }
+    {:ok, schema} = Schema.parse(json_schema())
+    %{schema | id: 42, version: 3}
   end
 
   defp schema_with_id do
-    lookup_table = :avro_schema_store.new()
-
-    %Avrora.Schema{
-      id: 42,
-      version: nil,
-      full_name: "io.confluent.Payment",
-      lookup_table: :avro_schema_store.add_type(erlavro_schema(), lookup_table),
-      schema: erlavro_schema(),
-      raw_schema: raw_schema()
-    }
+    {:ok, schema} = Schema.parse(json_schema())
+    %{schema | id: 42, version: nil}
   end
 
-  defp erlavro_schema do
-    :avro_json_decoder.decode_schema(raw_schema())
-  end
-
-  defp raw_schema do
+  defp json_schema do
     ~s({"namespace":"io.confluent","type":"record","name":"Payment","fields":[{"name":"id","type":"string"},{"name":"amount","type":"double"}]})
   end
 end

--- a/test/avrora/schema_test.exs
+++ b/test/avrora/schema_test.exs
@@ -7,11 +7,15 @@ defmodule Avrora.SchemaTest do
   describe "parse/1" do
     test "when payload is a valid json schema" do
       {:ok, avro} = Schema.parse(payment_json())
-      {type, _, _, _, _, fields, full_name, _} = avro.schema
+
+      {:ok, {type, _, _, _, _, fields, full_name, _}} =
+        :avro_schema_store.lookup_type("io.confluent.Payment", avro.lookup_table)
 
       assert type == :avro_record_type
       assert full_name == "io.confluent.Payment"
       assert length(fields) == 2
+
+      assert avro.full_name == "io.confluent.Payment"
       assert avro.raw_schema == payment_json()
     end
 

--- a/test/avrora/schema_test.exs
+++ b/test/avrora/schema_test.exs
@@ -6,22 +6,31 @@ defmodule Avrora.SchemaTest do
 
   describe "parse/1" do
     test "when payload is a valid json schema" do
-      {:ok, avro} = Schema.parse(payment_json())
-
-      {:ok, {type, _, _, _, _, fields, full_name, _}} =
-        :avro_schema_store.lookup_type("io.confluent.Payment", avro.lookup_table)
+      {:ok, schema} = Schema.parse(payment_json())
+      {:ok, {type, _, _, _, _, fields, full_name, _}} = Schema.to_erlavro(schema)
 
       assert type == :avro_record_type
       assert full_name == "io.confluent.Payment"
       assert length(fields) == 2
 
-      assert avro.full_name == "io.confluent.Payment"
-      assert avro.raw_schema == payment_json()
+      assert schema.full_name == "io.confluent.Payment"
+      assert schema.json == payment_json()
     end
 
     test "when payload is an invalid json shema" do
       assert Schema.parse("a:b") == {:error, "argument error"}
       assert Schema.parse("{}") == {:error, {:not_found, "type"}}
+    end
+  end
+
+  describe "to_erlavro" do
+    test "when payload is a valid json schema" do
+      {:ok, schema} = Schema.parse(payment_json())
+      {:ok, {type, _, _, _, _, fields, full_name, _}} = Schema.to_erlavro(schema)
+
+      assert type == :avro_record_type
+      assert full_name == "io.confluent.Payment"
+      assert length(fields) == 2
     end
   end
 

--- a/test/avrora/storage/file_test.exs
+++ b/test/avrora/storage/file_test.exs
@@ -7,23 +7,17 @@ defmodule Avrora.Storage.FileTest do
 
   describe "get/1" do
     test "when schema file was found" do
-      {:ok, avro} = File.get("io.confluent.Payment")
-      {type, _, _, _, _, fields, full_name, _} = avro.schema
+      {:ok, schema} = File.get("io.confluent.Payment")
 
-      assert type == :avro_record_type
-      assert full_name == "io.confluent.Payment"
-      assert length(fields) == 2
+      assert schema.full_name == "io.confluent.Payment"
     end
 
     test "when schema name contains version and when schema file was found" do
       output =
         capture_log(fn ->
-          {:ok, avro} = File.get("io.confluent.Payment:42")
-          {type, _, _, _, _, fields, full_name, _} = avro.schema
+          {:ok, schema} = File.get("io.confluent.Payment:42")
 
-          assert type == :avro_record_type
-          assert full_name == "io.confluent.Payment"
-          assert length(fields) == 2
+          assert schema.full_name == "io.confluent.Payment"
         end)
 
       assert output =~ "schema with version is not allowed"

--- a/test/avrora/storage/memory_test.exs
+++ b/test/avrora/storage/memory_test.exs
@@ -81,16 +81,12 @@ defmodule Avrora.Storage.MemoryTest do
   defp schema,
     do: %Avrora.Schema{
       id: 1,
-      schema: [],
-      raw_schema:
-        ~s({"type": "record", "name": "one", "fields": [{"name": "id", "type": "integer"}]})
+      json: ~s({"type": "record", "name": "one", "fields": [{"name": "id", "type": "integer"}]})
     }
 
   defp new_schema,
     do: %Avrora.Schema{
       id: 1,
-      schema: [],
-      raw_schema:
-        ~s({"type": "record", "name": "two", "fields": [{"name": "greeting", "type": "string"}]})
+      json: ~s({"type": "record", "name": "two", "fields": [{"name": "word", "type": "string"}]})
     }
 end

--- a/test/avrora/storage/registry_test.exs
+++ b/test/avrora/storage/registry_test.exs
@@ -25,14 +25,11 @@ defmodule Avrora.Storage.RegistryTest do
         }
       end)
 
-      {:ok, avro} = Registry.get("io.confluent.Payment")
-      {type, _, _, _, _, fields, full_name, _} = avro.schema
+      {:ok, schema} = Registry.get("io.confluent.Payment")
 
-      assert avro.id == 42
-      assert avro.version == 1
-      assert type == :avro_record_type
-      assert full_name == "io.confluent.Payment"
-      assert length(fields) == 2
+      assert schema.id == 42
+      assert schema.version == 1
+      assert schema.full_name == "io.confluent.Payment"
     end
 
     test "when request by subject name with version was successful" do
@@ -51,14 +48,11 @@ defmodule Avrora.Storage.RegistryTest do
         }
       end)
 
-      {:ok, avro} = Registry.get("io.confluent.Payment:10")
-      {type, _, _, _, _, fields, full_name, _} = avro.schema
+      {:ok, schema} = Registry.get("io.confluent.Payment:10")
 
-      assert avro.id == 42
-      assert avro.version == 10
-      assert type == :avro_record_type
-      assert full_name == "io.confluent.Payment"
-      assert length(fields) == 2
+      assert schema.id == 42
+      assert schema.version == 10
+      assert schema.full_name == "io.confluent.Payment"
     end
 
     test "when request by subject name was unsuccessful" do
@@ -80,14 +74,11 @@ defmodule Avrora.Storage.RegistryTest do
         {:ok, %{"schema" => json_schema()}}
       end)
 
-      {:ok, avro} = Registry.get(1)
-      {type, _, _, _, _, fields, full_name, _} = avro.schema
+      {:ok, schema} = Registry.get(1)
 
-      assert avro.id == 1
-      assert is_nil(avro.version)
-      assert type == :avro_record_type
-      assert full_name == "io.confluent.Payment"
-      assert length(fields) == 2
+      assert schema.id == 1
+      assert is_nil(schema.version)
+      assert schema.full_name == "io.confluent.Payment"
     end
 
     test "when request by global ID was unsuccessful" do
@@ -121,14 +112,11 @@ defmodule Avrora.Storage.RegistryTest do
         {:ok, %{"id" => 1}}
       end)
 
-      {:ok, avro} = Registry.put("io.confluent.Payment", json_schema())
-      {type, _, _, _, _, fields, full_name, _} = avro.schema
+      {:ok, schema} = Registry.put("io.confluent.Payment", json_schema())
 
-      assert avro.id == 1
-      assert is_nil(avro.version)
-      assert type == :avro_record_type
-      assert full_name == "io.confluent.Payment"
-      assert length(fields) == 2
+      assert schema.id == 1
+      assert is_nil(schema.version)
+      assert schema.full_name == "io.confluent.Payment"
     end
 
     test "when key contains version and request was successful" do
@@ -142,14 +130,11 @@ defmodule Avrora.Storage.RegistryTest do
 
       output =
         capture_log(fn ->
-          {:ok, avro} = Registry.put("io.confluent.Payment:42", json_schema())
-          {type, _, _, _, _, fields, full_name, _} = avro.schema
+          {:ok, schema} = Registry.put("io.confluent.Payment:42", json_schema())
 
-          assert avro.id == 1
-          assert is_nil(avro.version)
-          assert type == :avro_record_type
-          assert full_name == "io.confluent.Payment"
-          assert length(fields) == 2
+          assert schema.id == 1
+          assert is_nil(schema.version)
+          assert schema.full_name == "io.confluent.Payment"
         end)
 
       assert output =~ "schema with version is not allowed"

--- a/test/fixtures/schemas/io/confluent/Messenger.avsc
+++ b/test/fixtures/schemas/io/confluent/Messenger.avsc
@@ -1,0 +1,30 @@
+{
+  "type": "record",
+  "name": "Messenger",
+  "namespace": "io.confluent",
+  "fields": [
+    {
+      "name": "inbox",
+      "type": {
+        "type": "array",
+        "items": {
+          "type": "record",
+          "name": "Message",
+          "fields": [
+            {
+              "name": "text",
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "archive",
+      "type": {
+        "type": "array",
+        "items": "io.confluent.Message"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
When schema contains type reference by a name decoding will fail.

**TODO**
- [x] Cover fix by a test case