### PR TITLE
fix ReferenceCollector collect logic

### DIFF
--- a/lib/avrora/schema/reference_collector.ex
+++ b/lib/avrora/schema/reference_collector.ex
@@ -56,7 +56,7 @@ defmodule Avrora.Schema.ReferenceCollector do
   defp do_collect({:avro_union_type, _, _} = type) do
     type
     |> :avro_union.get_types()
-    |> List.foldl([], fn typ, memo -> memo ++ do_collect(typ) end)
+    |> Enum.flat_map(&do_collect/1)
   end
 
   defp do_collect({:avro_array_type, type, _}), do: do_collect(type)

--- a/lib/avrora/schema/reference_collector.ex
+++ b/lib/avrora/schema/reference_collector.ex
@@ -26,13 +26,13 @@ defmodule Avrora.Schema.ReferenceCollector do
       iex> json_schema = File.read!("test/fixtures/schemas/io/confluent/Account.avsc")
       iex> erlavro = :avro_json_decoder.decode_schema(json_schema, allow_bad_references: true)
       iex> Avrora.Schema.ReferenceCollector.collect(erlavro)
-      {:ok, ["io.confluent.PaymentHistory", "io.confluent.Messenger", "io.confluent.Email"]}
+      {:ok, ["io.confluent.Email", "io.confluent.Messenger", "io.confluent.PaymentHistory"]}
   """
   @spec collect(term()) :: {:ok, list(String.t())} | {:error, term()}
   def collect(schema) do
     collected =
       schema
-      |> collect([])
+      |> do_collect()
       |> List.foldl(%{ref: [], def: []}, fn {type, name}, memo ->
         Map.update(memo, type, [name], &[name | &1])
       end)
@@ -42,32 +42,32 @@ defmodule Avrora.Schema.ReferenceCollector do
     reason -> {:error, reason}
   end
 
-  defp collect({:avro_record_type, _, namespace, _, aliases, fields, fullname, _}, state) do
+  defp do_collect({:avro_record_type, _, namespace, _, aliases, fields, fullname, _}) do
     aliases =
       aliases
       |> :avro_util.canonicalize_aliases(namespace)
       |> Enum.map(&{:def, &1})
 
-    List.foldl(fields, [{:def, fullname} | aliases] ++ state, fn type, state ->
-      collect(type, state)
+    List.foldl(fields, [{:def, fullname} | aliases], fn type, memo ->
+      memo ++ do_collect(type)
     end)
   end
 
-  defp collect({:avro_union_type, _, _} = type, state) do
+  defp do_collect({:avro_union_type, _, _} = type) do
     type
     |> :avro_union.get_types()
-    |> List.foldl(state, fn typ, memo -> memo ++ collect(typ, state) end)
+    |> List.foldl([], fn typ, memo -> memo ++ do_collect(typ) end)
   end
 
-  defp collect({:avro_array_type, type, _}, state), do: collect(type, state)
-  defp collect({:avro_record_field, _, _, type, _, _, _}, state), do: collect(type, state)
-  defp collect({:avro_map_type, type, _}, state), do: collect(type, state)
-  defp collect({:avro_enum_type, _, _, _, _, _, _, _}, state), do: state
-  defp collect({:avro_fixed_type, _, _, _, _, _, _}, state), do: state
-  defp collect({:avro_primitive_type, _, _}, state), do: state
+  defp do_collect({:avro_array_type, type, _}), do: do_collect(type)
+  defp do_collect({:avro_record_field, _, _, type, _, _, _}), do: do_collect(type)
+  defp do_collect({:avro_map_type, type, _}), do: do_collect(type)
+  defp do_collect({:avro_enum_type, _, _, _, _, _, _, _}), do: []
+  defp do_collect({:avro_fixed_type, _, _, _, _, _, _}), do: []
+  defp do_collect({:avro_primitive_type, _, _}), do: []
 
-  defp collect(type, state) when is_binary(type) and type in @builtin_types, do: state
-  defp collect(type, state) when is_binary(type), do: [{:ref, type} | state]
+  defp do_collect(type) when is_binary(type) and type in @builtin_types, do: []
+  defp do_collect(type) when is_binary(type), do: [{:ref, type}]
 
-  defp collect(type, _state), do: throw({:unknown_type, type})
+  defp do_collect(type), do: throw({:unknown_type, type})
 end

--- a/test/avrora/schema/reference_collector_test.exs
+++ b/test/avrora/schema/reference_collector_test.exs
@@ -53,6 +53,12 @@ defmodule Avrora.Schema.ReferenceCollectorTest do
 
       assert references == []
     end
+
+    test "when schema contains many fields" do
+      {:ok, references} = ReferenceCollector.collect(record_with_many_fields())
+
+      assert references == []
+    end
   end
 
   defp record_with_fixed do
@@ -243,6 +249,13 @@ defmodule Avrora.Schema.ReferenceCollectorTest do
         ]
       }
     ) |> decode_schema()
+  end
+
+  defp record_with_many_fields do
+    File.read!(
+      Path.join(__DIR__, "../../../test/fixtures/schemas/io/confluent/MailgunEvent.avsc")
+    )
+    |> decode_schema()
   end
 
   defp decode_schema(json), do: :avro_json_decoder.decode_schema(json, allow_bad_references: true)

--- a/test/fixtures/schemas/io/confluent/MailgunEvent.avsc
+++ b/test/fixtures/schemas/io/confluent/MailgunEvent.avsc
@@ -1,0 +1,174 @@
+{
+  "namespace": "io.confluent",
+  "name": "MailgunEvent",
+  "type": "record",
+  "fields": [
+    { "name": "event", "type": "string" },
+    { "name": "id", "type": "string" },
+    { "name": "timestamp", "type": "float" },
+    {
+      "name": "log_level",
+      "type": { "type": "string", "bq.source_name": "log-level" }
+    },
+    { "name": "recipient", "type": ["null", "string"] },
+    {
+      "name": "recipient_domain",
+      "type": [
+        "null",
+        { "type": "string", "bq.source_name": "recipient-domain" }
+      ]
+    },
+    { "name": "reason", "type": ["null", "string"] },
+    { "name": "severity", "type": ["null", "string"] },
+    { "name": "url", "type": ["null", "string"] },
+    {
+      "name": "tags",
+      "type": ["null", { "type": "array", "items": "string" }]
+    },
+    {
+      "name": "user_variables",
+      "type": {
+        "type": "record",
+        "name": "UserVariables",
+        "bq.source_name": "user-variables",
+        "fields": [{ "name": "thread_id", "type": ["null", "string"] }]
+      }
+    },
+    {
+      "name": "envelope",
+      "type": [
+        "null",
+        {
+          "type": "record",
+          "name": "Envelope",
+          "fields": [
+            { "name": "sender", "type": ["null", "string"] },
+            { "name": "transport", "type": ["null", "string"] },
+            { "name": "targets", "type": ["null", "string"] }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "delivery_status",
+      "type": [
+        "null",
+        {
+          "type": "record",
+          "name": "DeliveryStatus",
+          "bq.source_name": "delivery-status",
+          "fields": [
+            { "name": "message", "type": ["null", "string"] },
+            { "name": "description", "type": ["null", "string"] },
+            {
+              "name": "attempt_no",
+              "type": [
+                "null",
+                { "type": "int", "bq.source_name": "attempt-no" }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "client_info",
+      "type": [
+        "null",
+        {
+          "type": "record",
+          "name": "ClientInfo",
+          "bq.source_name": "client-info",
+          "fields": [
+            {
+              "name": "client_type",
+              "type": [
+                "null",
+                { "type": "string", "bq.source_name": "client-type" }
+              ]
+            },
+            {
+              "name": "client_os",
+              "type": [
+                "null",
+                { "type": "string", "bq.source_name": "client-os" }
+              ]
+            },
+            {
+              "name": "device_type",
+              "type": [
+                "null",
+                { "type": "string", "bq.source_name": "device-type" }
+              ]
+            },
+            {
+              "name": "client_name",
+              "type": [
+                "null",
+                { "type": "string", "bq.source_name": "client-name" }
+              ]
+            },
+            {
+              "name": "user_agent",
+              "type": [
+                "null",
+                { "type": "string", "bq.source_name": "user-agent" }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "geolocation",
+      "type": [
+        "null",
+        {
+          "type": "record",
+          "name": "Geolocation",
+          "fields": [
+            { "name": "country", "type": ["null", "string"] },
+            { "name": "region", "type": ["null", "string"] },
+            { "name": "city", "type": ["null", "string"] }
+          ]
+        }
+      ]
+    },
+    { "name": "ip", "type": ["null", "string"] },
+    {
+      "name": "message",
+      "type": [
+        "null",
+        {
+          "type": "record",
+          "name": "Message",
+          "fields": [
+            {
+              "name": "headers",
+              "type": [
+                "null",
+                {
+                  "type": "record",
+                  "name": "Headers",
+                  "fields": [
+                    { "name": "to", "type": ["null", "string"] },
+                    {
+                      "name": "message_id",
+                      "type": [
+                        "null",
+                        { "type": "string", "bq.source_name": "message-id" }
+                      ]
+                    },
+                    { "name": "from", "type": ["null", "string"] },
+                    { "name": "subject", "type": ["null", "string"] }
+                  ]
+                }
+              ]
+            },
+            { "name": "size", "type": ["null", "int"] }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/fixtures/schemas/io/confluent/MailgunEvent.avsc
+++ b/test/fixtures/schemas/io/confluent/MailgunEvent.avsc
@@ -3,35 +3,85 @@
   "name": "MailgunEvent",
   "type": "record",
   "fields": [
-    { "name": "event", "type": "string" },
-    { "name": "id", "type": "string" },
-    { "name": "timestamp", "type": "float" },
+    {
+      "name": "event",
+      "type": "string"
+    },
+    {
+      "name": "id",
+      "type": "string"
+    },
+    {
+      "name": "timestamp",
+      "type": "float"
+    },
     {
       "name": "log_level",
-      "type": { "type": "string", "bq.source_name": "log-level" }
+      "type": {
+        "type": "string"
+      }
     },
-    { "name": "recipient", "type": ["null", "string"] },
+    {
+      "name": "recipient",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     {
       "name": "recipient_domain",
       "type": [
         "null",
-        { "type": "string", "bq.source_name": "recipient-domain" }
+        {
+          "type": "string"
+        }
       ]
     },
-    { "name": "reason", "type": ["null", "string"] },
-    { "name": "severity", "type": ["null", "string"] },
-    { "name": "url", "type": ["null", "string"] },
+    {
+      "name": "reason",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    {
+      "name": "severity",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    {
+      "name": "url",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     {
       "name": "tags",
-      "type": ["null", { "type": "array", "items": "string" }]
+      "type": [
+        "null",
+        {
+          "type": "array",
+          "items": "string"
+        }
+      ]
     },
     {
       "name": "user_variables",
       "type": {
         "type": "record",
         "name": "UserVariables",
-        "bq.source_name": "user-variables",
-        "fields": [{ "name": "thread_id", "type": ["null", "string"] }]
+        "fields": [
+          {
+            "name": "thread_id",
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        ]
       }
     },
     {
@@ -42,9 +92,27 @@
           "type": "record",
           "name": "Envelope",
           "fields": [
-            { "name": "sender", "type": ["null", "string"] },
-            { "name": "transport", "type": ["null", "string"] },
-            { "name": "targets", "type": ["null", "string"] }
+            {
+              "name": "sender",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            {
+              "name": "transport",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            {
+              "name": "targets",
+              "type": [
+                "null",
+                "string"
+              ]
+            }
           ]
         }
       ]
@@ -56,15 +124,28 @@
         {
           "type": "record",
           "name": "DeliveryStatus",
-          "bq.source_name": "delivery-status",
           "fields": [
-            { "name": "message", "type": ["null", "string"] },
-            { "name": "description", "type": ["null", "string"] },
+            {
+              "name": "message",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            {
+              "name": "description",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
             {
               "name": "attempt_no",
               "type": [
                 "null",
-                { "type": "int", "bq.source_name": "attempt-no" }
+                {
+                  "type": "int"
+                }
               ]
             }
           ]
@@ -78,41 +159,50 @@
         {
           "type": "record",
           "name": "ClientInfo",
-          "bq.source_name": "client-info",
           "fields": [
             {
               "name": "client_type",
               "type": [
                 "null",
-                { "type": "string", "bq.source_name": "client-type" }
+                {
+                  "type": "string"
+                }
               ]
             },
             {
               "name": "client_os",
               "type": [
                 "null",
-                { "type": "string", "bq.source_name": "client-os" }
+                {
+                  "type": "string"
+                }
               ]
             },
             {
               "name": "device_type",
               "type": [
                 "null",
-                { "type": "string", "bq.source_name": "device-type" }
+                {
+                  "type": "string"
+                }
               ]
             },
             {
               "name": "client_name",
               "type": [
                 "null",
-                { "type": "string", "bq.source_name": "client-name" }
+                {
+                  "type": "string"
+                }
               ]
             },
             {
               "name": "user_agent",
               "type": [
                 "null",
-                { "type": "string", "bq.source_name": "user-agent" }
+                {
+                  "type": "string"
+                }
               ]
             }
           ]
@@ -127,14 +217,38 @@
           "type": "record",
           "name": "Geolocation",
           "fields": [
-            { "name": "country", "type": ["null", "string"] },
-            { "name": "region", "type": ["null", "string"] },
-            { "name": "city", "type": ["null", "string"] }
+            {
+              "name": "country",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            {
+              "name": "region",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            {
+              "name": "city",
+              "type": [
+                "null",
+                "string"
+              ]
+            }
           ]
         }
       ]
     },
-    { "name": "ip", "type": ["null", "string"] },
+    {
+      "name": "ip",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     {
       "name": "message",
       "type": [
@@ -151,21 +265,47 @@
                   "type": "record",
                   "name": "Headers",
                   "fields": [
-                    { "name": "to", "type": ["null", "string"] },
+                    {
+                      "name": "to",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
                     {
                       "name": "message_id",
                       "type": [
                         "null",
-                        { "type": "string", "bq.source_name": "message-id" }
+                        {
+                          "type": "string"
+                        }
                       ]
                     },
-                    { "name": "from", "type": ["null", "string"] },
-                    { "name": "subject", "type": ["null", "string"] }
+                    {
+                      "name": "from",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    },
+                    {
+                      "name": "subject",
+                      "type": [
+                        "null",
+                        "string"
+                      ]
+                    }
                   ]
                 }
               ]
             },
-            { "name": "size", "type": ["null", "int"] }
+            {
+              "name": "size",
+              "type": [
+                "null",
+                "int"
+              ]
+            }
           ]
         }
       ]


### PR DESCRIPTION
There is no need to capture the references via both return value and
accumulator. The old logic leads to exponential memory usage due to
repeated concatenation of same values again and again. Once the number
of fields in a schema crosses a threshold this leads to OOM