### PR TITLE
Fix broken ETS references

### DIFF
--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -2,8 +2,9 @@
   # NOTE: This code doesn't pass dialyxir because of the opaque types of erlavro functions.
   #       The fix of dialyxir requires to silence too much functions and that's sad.
   #       https://github.com/klarna/erlavro/blob/3dcb4a90af88bfe297ca60781265fbba025db48d/src/avro_binary_encoder.erl#L87-L88
+  {":0:unknown_function Function ExUnit.Callbacks.on_exit/1 does not exist."},
   {"lib/avrora/encoder.ex", :call_without_opaque},
-  {"lib/avrora/encoder.ex", :pattern_match, 117},
-  {"lib/avrora/encoder.ex", :unused_fun, 184},
-  {"lib/avrora/encoder.ex", :unused_fun, 190}
+  {"lib/avrora/encoder.ex", :pattern_match, 118},
+  {"lib/avrora/encoder.ex", :unused_fun, 185},
+  {"lib/avrora/encoder.ex", :unused_fun, 191}
 ]

--- a/lib/avrora.ex
+++ b/lib/avrora.ex
@@ -12,9 +12,10 @@ defmodule Avrora do
   @impl true
   def init(_state \\ []) do
     children = [
+      Avrora.ETS,
       Avrora.Storage.Memory
     ]
 
-    Supervisor.init(children, strategy: :one_for_one)
+    Supervisor.init(children, strategy: :one_for_all)
   end
 end

--- a/lib/avrora/config.ex
+++ b/lib/avrora/config.ex
@@ -14,6 +14,7 @@ defmodule Avrora.Config do
       * `memory_storage` module which handles memory operations, default `Avrora.Storage.Memory`
       * `registry_storage` module which handles Schema Registry requests, default `Avrora.Storage.Registry`
       * `http_client` module which handles HTTP client requests to Schema Registry, default `Avrora.HTTPClient`
+      * `ets_lib` module which creates ETS tables with call `Module.new/0`
   """
 
   @doc false
@@ -36,6 +37,9 @@ defmodule Avrora.Config do
 
   @doc false
   def http_client, do: get_env(:http_client, Avrora.HTTPClient)
+
+  @doc false
+  def ets_lib, do: get_env(:ets_lib, Avrora.ETS)
 
   defp get_env(name, default), do: Application.get_env(:avrora, name, default)
 end

--- a/lib/avrora/encoder.ex
+++ b/lib/avrora/encoder.ex
@@ -4,7 +4,8 @@ defmodule Avrora.Encoder do
   """
 
   require Logger
-  alias Avrora.{Mapper, Name, Resolver, Schema}
+  alias Avrora.{Mapper, Resolver, Schema}
+  alias Avrora.Schema.Name
 
   @registry_magic_bytes <<0::size(8)>>
   @object_container_magic_bytes <<"Obj", 1>>

--- a/lib/avrora/ets.ex
+++ b/lib/avrora/ets.ex
@@ -1,0 +1,46 @@
+defmodule Avrora.ETS do
+  @moduledoc """
+  A host process for ets tables. It is used only to create new
+  tables.
+
+  This process will be in the save supervision tree as `Avrora.Storage.Memory`
+  with a stragety `one for all`.
+
+  See more:
+    - https://github.com/Strech/avrora/issues/21
+    - https://elixirforum.com/t/do-we-need-a-process-for-ets-tables/22705
+  """
+
+  use GenServer
+
+  def start_link(opts \\ []) do
+    {name_opts, _} = Keyword.split(opts, [:name])
+    opts = Keyword.merge([name: __MODULE__], name_opts)
+
+    GenServer.start_link(__MODULE__, [], opts)
+  end
+
+  @impl true
+  def init(_state \\ []), do: {:ok, []}
+
+  @impl true
+  def handle_call({:new}, _from, state) do
+    table = :ets.new(__MODULE__, [:public, {:read_concurrency, true}])
+    {:reply, table, state}
+  end
+
+  @doc """
+  Creates a new Erlang Term Store.
+
+  ## Examples:
+
+      iex> {:ok, _} = Avrora.ETS.start_link()
+      iex> Avrora.ETS.new() |> :ets.info() |> Keyword.get(:size)
+      0
+  """
+  def new, do: new(__MODULE__)
+
+  @doc false
+  @spec new(pid() | atom()) :: reference()
+  def new(pid), do: GenServer.call(pid, {:new})
+end

--- a/lib/avrora/resolver.ex
+++ b/lib/avrora/resolver.ex
@@ -4,7 +4,8 @@ defmodule Avrora.Resolver do
   """
 
   require Logger
-  alias Avrora.{Config, Name}
+  alias Avrora.Config
+  alias Avrora.Schema.Name
 
   @doc """
   Resolve schema, trying multiple methods. First tries integer id, then string name.

--- a/lib/avrora/schema/name.ex
+++ b/lib/avrora/schema/name.ex
@@ -1,4 +1,4 @@
-defmodule Avrora.Name do
+defmodule Avrora.Schema.Name do
   @moduledoc """
   Struct for versioned schema names like `io.confluent.Payment:42`.
   """
@@ -17,10 +17,10 @@ defmodule Avrora.Name do
 
   ## Examples
 
-      iex> Avrora.Name.parse("Payment")
-      {:ok, %Avrora.Name{name: "Payment", version: nil}}
-      iex> Avrora.Name.parse("io.confluent.Payment:42")
-      {:ok, %Avrora.Name{name: "io.confluent.Payment", version: 42}}
+      iex> Avrora.Schema.Name.parse("Payment")
+      {:ok, %Avrora.Schema.Name{name: "Payment", version: nil}}
+      iex> Avrora.Schema.Name.parse("io.confluent.Payment:42")
+      {:ok, %Avrora.Schema.Name{name: "io.confluent.Payment", version: 42}}
   """
   @spec parse(String.t()) :: {:ok, t()} | {:error, term()}
   def parse(payload) when is_binary(payload) do

--- a/lib/avrora/storage.ex
+++ b/lib/avrora/storage.ex
@@ -27,5 +27,7 @@ defmodule Avrora.Storage do
 
     @callback expire(key :: Storage.schema_id(), ttl :: timeout()) ::
                 {:ok, timestamp :: timestamp()} | {:error, reason :: term()}
+
+    @callback flush() :: {:ok, result :: boolean()} | {:error, reason :: term()}
   end
 end

--- a/lib/avrora/storage/file.ex
+++ b/lib/avrora/storage/file.ex
@@ -7,7 +7,8 @@ defmodule Avrora.Storage.File do
   """
 
   require Logger
-  alias Avrora.{Config, Name, Schema}
+  alias Avrora.{Config, Schema}
+  alias Avrora.Schema.Name
 
   @behaviour Avrora.Storage
   @extension ".avsc"

--- a/lib/avrora/storage/registry.ex
+++ b/lib/avrora/storage/registry.ex
@@ -9,7 +9,8 @@ defmodule Avrora.Storage.Registry do
 
   require Logger
 
-  alias Avrora.{Config, Name, Schema}
+  alias Avrora.{Config, Schema}
+  alias Avrora.Schema.Name
 
   @behaviour Avrora.Storage
   @content_type "application/vnd.schemaregistry.v1+json"

--- a/lib/avrora/test_case.ex
+++ b/lib/avrora/test_case.ex
@@ -1,0 +1,12 @@
+defmodule Avrora.TestCase do
+  @moduledoc """
+  TODO: Write documentation
+  """
+
+  alias Avrora.Storage.Memory
+
+  @doc false
+  def cleanup_storage!(_context \\ %{}) do
+    ExUnit.Callbacks.on_exit(&Memory.flush/0)
+  end
+end

--- a/lib/avrora/test_case.ex
+++ b/lib/avrora/test_case.ex
@@ -1,11 +1,33 @@
 defmodule Avrora.TestCase do
   @moduledoc """
-  TODO: Write documentation
+  An ExUnit helper.
   """
 
   alias Avrora.Storage.Memory
 
-  @doc false
+  @doc """
+    A hook function to be used in `setup`-hook to clean memory storage.
+
+    ## Examples:
+
+        defmodule MyTest do
+          use ExUnit.Case, async: true
+
+          import Avrora.TestCase
+          setup :cleanup_storage!
+
+          test "memory storage was filled" do
+            asset Avrora.Storage.Memory.get("some") == nil
+
+            Avrora.Storage.Memory.put("some", 42)
+            asset Avrora.Storage.Memory.get("some") == 42
+          end
+
+          test "memory storage is clean" do
+            asset Avrora.Storage.Memory.get("some") == nil
+          end
+        end
+  """
   def cleanup_storage!(_context \\ %{}) do
     ExUnit.Callbacks.on_exit(&Memory.flush/0)
   end

--- a/test/avrora/ets_test.exs
+++ b/test/avrora/ets_test.exs
@@ -1,0 +1,24 @@
+defmodule Avrora.ETSTest do
+  use ExUnit.Case, async: true
+  doctest Avrora.ETS
+
+  alias Avrora.ETS
+
+  setup do
+    pid = start_supervised!({ETS, name: :test_ets})
+
+    %{ets: pid}
+  end
+
+  describe "new/2" do
+    test "when table was created", %{ets: pid} do
+      table_size =
+        pid
+        |> ETS.new()
+        |> :ets.info()
+        |> Keyword.get(:size)
+
+      assert table_size == 0
+    end
+  end
+end

--- a/test/avrora/schema/name_test.exs
+++ b/test/avrora/schema/name_test.exs
@@ -1,8 +1,8 @@
-defmodule Avrora.NameTest do
+defmodule Avrora.Schema.NameTest do
   use ExUnit.Case, async: true
-  doctest Avrora.Name
+  doctest Avrora.Schema.Name
 
-  alias Avrora.Name
+  alias Avrora.Schema.Name
 
   describe "parse/1" do
     test "when only name part is present" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,6 +2,7 @@ Application.put_env(:avrora, :http_client, Avrora.HTTPClientMock)
 Application.put_env(:avrora, :file_storage, Avrora.Storage.FileMock)
 Application.put_env(:avrora, :memory_storage, Avrora.Storage.MemoryMock)
 Application.put_env(:avrora, :registry_storage, Avrora.Storage.RegistryMock)
+Application.put_env(:avrora, :ets_lib, :avro_schema_store)
 
 Application.put_env(:avrora, :registry_url, "http://reg.loc")
 Application.put_env(:avrora, :schemas_path, Path.expand("./test/fixtures/schemas"))


### PR DESCRIPTION
This PR include 3 major changes:

1. `Avrora.Name` module was moved to `Avrora.Schema.Name`
2. `Avrora.TestCase` helper module gets `cleanup_storage!/1` function to clean storage between tests
3. `Avrora.ETS` module now supervisioned together with `Avrora.Storage.Memory` and owns all ETS tables generated by `Avrora.Schema`

Resolves: #21