### PR TITLE
Add SASL PLAIN support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,13 @@ Configure the library in `config/config.exs`:
 ```elixir
 config :avrora,
   registry_url: "http://localhost:8081",
+  registry_sasl: {:plain, "username", "password"}
   schemas_path: Path.expand("./priv/schemas"),
   names_cache_ttl: :timer.minutes(5)
 ```
 
 - `registry_url` - URL for the Confluent Schema Registry, default `nil`
+- `registry_sasl` - SASL authentication for the Confluent Schema Registry, default `nil`
 - `schemas_path` - Base path for locally stored schema files, default `./priv/schemas`
 - `names_cache_ttl` - Time in ms to cache schemas by name in memory, default `300_000`.
 
@@ -57,6 +59,8 @@ Set `names_cache_ttl` to `:infinity` to cache forever. This is safe when
 schemas are resolved in the Schema Registry by numeric id or **versioned** name, as
 it is unique. If the schema is resolved by name, then someone may update the
 schema, so the TTL ensures that it will be reloaded to use the latest version.
+
+Avrora supports SASL `PLAIN` authentication mechanism out of the box. To use it, set `registry_sasl` to `{mechanism, username, password}` where `mechanism` is the authentication mechanism atom `:plain`, `username` is the Confluent Schema Registry API access key and `password` is the Confluent Schema Registry API access secret. Alternatively, you can also use `{mechanism, file}` where `file` is the path to a text file that contains two lines, first line for username and second line for password.
 
 ## Start cache process
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -3,6 +3,7 @@ use Mix.Config
 config :avrora,
   schemas_path: Path.expand("./test/fixtures/schemas"),
   registry_url: nil,
+  registry_sasl: nil,
   names_cache_ttl: :timer.seconds(30)
 
 config :logger, :console, format: "$time $metadata[$level] $levelpad$message\n"

--- a/lib/avrora/config.ex
+++ b/lib/avrora/config.ex
@@ -24,6 +24,9 @@ defmodule Avrora.Config do
   def registry_url, do: get_env(:registry_url, nil)
 
   @doc false
+  def registry_sasl, do: get_env(:registry_sasl, nil)
+
+  @doc false
   def names_cache_ttl, do: get_env(:names_cache_ttl, :timer.minutes(5))
 
   @doc false

--- a/lib/avrora/http_client.ex
+++ b/lib/avrora/http_client.ex
@@ -3,13 +3,13 @@ defmodule Avrora.HTTPClient do
   Minimal HTTP client using built-in Erlang `httpc` library.
   """
 
-  @callback get(String.t()) :: {:ok, map()} | {:error, term()}
+  @callback get(String.t(), keyword(String.t())) :: {:ok, map()} | {:error, term()}
   @callback post(String.t(), String.t(), keyword(String.t())) :: {:ok, map()} | {:error, term()}
 
   @doc false
-  @spec get(String.t()) :: {:ok, map()} | {:error, term()}
-  def get(url) do
-    case :httpc.request(:get, {'#{url}', []}, [], []) do
+  @spec get(String.t(), keyword(String.t())) :: {:ok, map()} | {:error, term()}
+  def get(url, headers: headers) do
+    case :httpc.request(:get, {'#{url}', headers}, [], []) do
       {:ok, {{_, status, _}, _, body}} ->
         handle(status, body)
 
@@ -20,10 +20,10 @@ defmodule Avrora.HTTPClient do
 
   @doc false
   @spec post(String.t(), String.t(), keyword(String.t())) :: {:ok, map()} | {:error, term()}
-  def post(url, payload, content_type: content_type) when is_binary(payload) do
+  def post(url, payload, headers: headers, content_type: content_type) when is_binary(payload) do
     with {:ok, body} <- Jason.encode(%{"schema" => payload}),
          {:ok, {{_, status, _}, _, body}} <-
-           :httpc.request(:post, {'#{url}', [], [content_type], body}, [], []) do
+           :httpc.request(:post, {'#{url}', headers, [content_type], body}, [], []) do
       handle(status, body)
     end
   end

--- a/lib/avrora/resolver.ex
+++ b/lib/avrora/resolver.ex
@@ -100,7 +100,12 @@ defmodule Avrora.Resolver do
             memory_storage().put(schema.id, schema)
           end
 
-        {:error, :unconfigured_registry_url} ->
+        {:error, reason}
+        when reason in [
+               :unconfigured_registry_url,
+               :malformed_registry_sasl,
+               :no_such_registry_sasl_file
+             ] ->
           with {:ok, schema} <- file_storage().get(name),
                do: memory_storage().put(schema_name.name, schema)
 

--- a/test/avrora/storage/registry_test.exs
+++ b/test/avrora/storage/registry_test.exs
@@ -11,7 +11,7 @@ defmodule Avrora.Storage.RegistryTest do
   describe "get/1" do
     test "when request by subject name without version was successful" do
       Avrora.HTTPClientMock
-      |> expect(:get, fn url ->
+      |> expect(:get, fn url, _ ->
         assert url == "http://reg.loc/subjects/io.confluent.Payment/versions/latest"
 
         {
@@ -34,7 +34,7 @@ defmodule Avrora.Storage.RegistryTest do
 
     test "when request by subject name with version was successful" do
       Avrora.HTTPClientMock
-      |> expect(:get, fn url ->
+      |> expect(:get, fn url, _ ->
         assert url == "http://reg.loc/subjects/io.confluent.Payment/versions/10"
 
         {
@@ -57,7 +57,7 @@ defmodule Avrora.Storage.RegistryTest do
 
     test "when request by subject name was unsuccessful" do
       Avrora.HTTPClientMock
-      |> expect(:get, fn url ->
+      |> expect(:get, fn url, _ ->
         assert url == "http://reg.loc/subjects/io.confluent.Payment/versions/latest"
 
         {:error, subject_not_found_parsed_error()}
@@ -68,7 +68,7 @@ defmodule Avrora.Storage.RegistryTest do
 
     test "when request by global ID was successful" do
       Avrora.HTTPClientMock
-      |> expect(:get, fn url ->
+      |> expect(:get, fn url, _ ->
         assert url == "http://reg.loc/schemas/ids/1"
 
         {:ok, %{"schema" => json_schema()}}
@@ -83,7 +83,7 @@ defmodule Avrora.Storage.RegistryTest do
 
     test "when request by global ID was unsuccessful" do
       Avrora.HTTPClientMock
-      |> expect(:get, fn url ->
+      |> expect(:get, fn url, _ ->
         assert url == "http://reg.loc/schemas/ids/1"
 
         {:error, version_not_found_parsed_error()}
@@ -160,6 +160,114 @@ defmodule Avrora.Storage.RegistryTest do
                {:error, :unconfigured_registry_url}
 
       Application.put_env(:avrora, :registry_url, registry_url)
+    end
+
+    test "when registry sasl is malformed" do
+      registry_sasl = Application.get_env(:avrora, :registry_sasl)
+      Application.put_env(:avrora, :registry_sasl, {:plain, "user", "pass", "unknown"})
+
+      assert Registry.put("anything", ~s({"type":"string"})) == {:error, :malformed_registry_sasl}
+
+      Application.put_env(:avrora, :registry_sasl, registry_sasl)
+    end
+
+    test "when registry sasl file not exists" do
+      registry_sasl = Application.get_env(:avrora, :registry_sasl)
+      Application.put_env(:avrora, :registry_sasl, {:plain, "unknown"})
+
+      output =
+        capture_log(fn ->
+          assert Registry.put("anything", ~s({"type":"string"})) ==
+                   {:error, :no_such_registry_sasl_file}
+        end)
+
+      output =~ "no such registry sasl file found unknown"
+
+      Application.put_env(:avrora, :registry_sasl, registry_sasl)
+    end
+
+    test "when registry sasl file is configured" do
+      Avrora.HTTPClientMock
+      |> expect(:post, fn url, payload, headers: headers, content_type: _ ->
+        base64 = :base64.encode_to_string("avrora_username:avrora_password")
+
+        assert url == "https://reg.loc/subjects/io.confluent.Payment/versions"
+        assert payload == json_schema()
+        assert headers == [{'Authorization', 'Basic #{base64}'}]
+
+        {:ok, %{"id" => 1}}
+      end)
+
+      registry_url = Application.get_env(:avrora, :registry_url)
+      registry_sasl = Application.get_env(:avrora, :registry_sasl)
+      Application.put_env(:avrora, :registry_url, "https://reg.loc")
+      Application.put_env(:avrora, :registry_sasl, {:plain, "./test/fixtures/sasl"})
+
+      {:ok, schema} = Registry.put("io.confluent.Payment", json_schema())
+
+      assert schema.id == 1
+      assert is_nil(schema.version)
+      assert schema.full_name == "io.confluent.Payment"
+
+      Application.put_env(:avrora, :registry_url, registry_url)
+      Application.put_env(:avrora, :registry_sasl, registry_sasl)
+    end
+
+    test "when registry sasl is configured" do
+      Avrora.HTTPClientMock
+      |> expect(:post, fn url, payload, headers: headers, content_type: _ ->
+        base64 = :base64.encode_to_string("avrora_username:avrora_password")
+
+        assert url == "https://reg.loc/subjects/io.confluent.Payment/versions"
+        assert payload == json_schema()
+        assert headers == [{'Authorization', 'Basic #{base64}'}]
+
+        {:ok, %{"id" => 1}}
+      end)
+
+      registry_url = Application.get_env(:avrora, :registry_url)
+      registry_sasl = Application.get_env(:avrora, :registry_sasl)
+      Application.put_env(:avrora, :registry_url, "https://reg.loc")
+      Application.put_env(:avrora, :registry_sasl, {:plain, "avrora_username", "avrora_password"})
+
+      {:ok, schema} = Registry.put("io.confluent.Payment", json_schema())
+
+      assert schema.id == 1
+      assert is_nil(schema.version)
+      assert schema.full_name == "io.confluent.Payment"
+
+      Application.put_env(:avrora, :registry_url, registry_url)
+      Application.put_env(:avrora, :registry_sasl, registry_sasl)
+    end
+
+    test "when registry sasl is configured without `https`" do
+      Avrora.HTTPClientMock
+      |> expect(:post, fn url, payload, headers: headers, content_type: _ ->
+        base64 = :base64.encode_to_string("avrora_username:avrora_password")
+
+        assert url == "http://reg.loc/subjects/io.confluent.Payment/versions"
+        assert payload == json_schema()
+        assert headers == [{'Authorization', 'Basic #{base64}'}]
+
+        {:ok, %{"id" => 1}}
+      end)
+
+      registry_sasl = Application.get_env(:avrora, :registry_sasl)
+      Application.put_env(:avrora, :registry_sasl, {:plain, "avrora_username", "avrora_password"})
+
+      output =
+        capture_log(fn ->
+          {:ok, schema} = Registry.put("io.confluent.Payment", json_schema())
+
+          assert schema.id == 1
+          assert is_nil(schema.version)
+          assert schema.full_name == "io.confluent.Payment"
+        end)
+
+      assert output =~ "unsecure `http` call over sasl, consider using `https` instead"
+      assert output =~ "new schema `io.confluent.Payment` stored with global id `1`"
+
+      Application.put_env(:avrora, :registry_sasl, registry_sasl)
     end
   end
 

--- a/test/fixtures/sasl
+++ b/test/fixtures/sasl
@@ -1,0 +1,2 @@
+avrora_username
+avrora_password

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,6 +5,7 @@ Application.put_env(:avrora, :registry_storage, Avrora.Storage.RegistryMock)
 Application.put_env(:avrora, :ets_lib, :avro_schema_store)
 
 Application.put_env(:avrora, :registry_url, "http://reg.loc")
+Application.put_env(:avrora, :registry_sasl, nil)
 Application.put_env(:avrora, :schemas_path, Path.expand("./test/fixtures/schemas"))
 Application.put_env(:avrora, :names_cache_ttl, :infinity)
 


### PR DESCRIPTION
Supports SASL PLAIN mechanism in order to connect to Schema Registry Confluent Cloud.