### PR TITLE
Add support for HTTP Basic Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,13 @@ Configure the library in `config/config.exs`:
 ```elixir
 config :avrora,
   registry_url: "http://localhost:8081",
+  registry_auth: {:basic, "username", "password"}
   schemas_path: Path.expand("./priv/schemas"),
   names_cache_ttl: :timer.minutes(5)
 ```
 
 - `registry_url` - URL for the Confluent Schema Registry, default `nil`
+- `registry_auth` - Authentication for the Confluent Schema Registry, default `nil`
 - `schemas_path` - Base path for locally stored schema files, default `./priv/schemas`
 - `names_cache_ttl` - Time in ms to cache schemas by name in memory, default `300_000`.
 
@@ -57,6 +59,8 @@ Set `names_cache_ttl` to `:infinity` to cache forever. This is safe when
 schemas are resolved in the Schema Registry by numeric id or **versioned** name, as
 it is unique. If the schema is resolved by name, then someone may update the
 schema, so the TTL ensures that it will be reloaded to use the latest version.
+
+Avrora currently supports `Basic` authentication mechanism out of the box. To use it, set `registry_auth` to `{mechanism, username, password}` where `mechanism` is the authentication mechanism atom `:basic`, `username` is the Confluent Schema Registry API access key and `password` is the Confluent Schema Registry API access secret. Alternatively, you can also use `{mechanism, file}` where `file` is the path to a text file that contains two lines, first line for username and second line for password.
 
 ## Start cache process
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -3,6 +3,7 @@ use Mix.Config
 config :avrora,
   schemas_path: Path.expand("./test/fixtures/schemas"),
   registry_url: nil,
+  registry_auth: nil,
   names_cache_ttl: :timer.seconds(30)
 
 config :logger, :console, format: "$time $metadata[$level] $levelpad$message\n"

--- a/lib/avrora/config.ex
+++ b/lib/avrora/config.ex
@@ -24,6 +24,9 @@ defmodule Avrora.Config do
   def registry_url, do: get_env(:registry_url, nil)
 
   @doc false
+  def registry_auth, do: get_env(:registry_auth, nil)
+
+  @doc false
   def names_cache_ttl, do: get_env(:names_cache_ttl, :timer.minutes(5))
 
   @doc false

--- a/lib/avrora/http_client.ex
+++ b/lib/avrora/http_client.ex
@@ -3,13 +3,13 @@ defmodule Avrora.HTTPClient do
   Minimal HTTP client using built-in Erlang `httpc` library.
   """
 
-  @callback get(String.t()) :: {:ok, map()} | {:error, term()}
+  @callback get(String.t(), keyword(String.t())) :: {:ok, map()} | {:error, term()}
   @callback post(String.t(), String.t(), keyword(String.t())) :: {:ok, map()} | {:error, term()}
 
   @doc false
-  @spec get(String.t()) :: {:ok, map()} | {:error, term()}
-  def get(url) do
-    case :httpc.request(:get, {'#{url}', []}, [], []) do
+  @spec get(String.t(), keyword(String.t())) :: {:ok, map()} | {:error, term()}
+  def get(url, headers: headers) do
+    case :httpc.request(:get, {'#{url}', headers}, [], []) do
       {:ok, {{_, status, _}, _, body}} ->
         handle(status, body)
 
@@ -20,10 +20,10 @@ defmodule Avrora.HTTPClient do
 
   @doc false
   @spec post(String.t(), String.t(), keyword(String.t())) :: {:ok, map()} | {:error, term()}
-  def post(url, payload, content_type: content_type) when is_binary(payload) do
+  def post(url, payload, headers: headers, content_type: content_type) when is_binary(payload) do
     with {:ok, body} <- Jason.encode(%{"schema" => payload}),
          {:ok, {{_, status, _}, _, body}} <-
-           :httpc.request(:post, {'#{url}', [], [content_type], body}, [], []) do
+           :httpc.request(:post, {'#{url}', headers, [content_type], body}, [], []) do
       handle(status, body)
     end
   end

--- a/lib/avrora/resolver.ex
+++ b/lib/avrora/resolver.ex
@@ -100,7 +100,12 @@ defmodule Avrora.Resolver do
             memory_storage().put(schema.id, schema)
           end
 
-        {:error, :unconfigured_registry_url} ->
+        {:error, reason}
+        when reason in [
+               :unconfigured_registry_url,
+               :malformed_registry_auth,
+               :no_such_registry_auth_file
+             ] ->
           with {:ok, schema} <- file_storage().get(name),
                do: memory_storage().put(schema_name.name, schema)
 

--- a/test/fixtures/auth
+++ b/test/fixtures/auth
@@ -1,0 +1,2 @@
+avrora_username
+avrora_password

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -5,6 +5,7 @@ Application.put_env(:avrora, :registry_storage, Avrora.Storage.RegistryMock)
 Application.put_env(:avrora, :ets_lib, :avro_schema_store)
 
 Application.put_env(:avrora, :registry_url, "http://reg.loc")
+Application.put_env(:avrora, :registry_auth, nil)
 Application.put_env(:avrora, :schemas_path, Path.expand("./test/fixtures/schemas"))
 Application.put_env(:avrora, :names_cache_ttl, :infinity)
 


### PR DESCRIPTION
Hi, @Strech,

The feature I have implemented is a [HTTP Basic Auth to connect into the Confluent Cloud](https://docs.confluent.io/current/security/basic-auth.html), implement the SASL authentication mechanism is a bit more complicated, and maybe in the future, I will give it a try. I have closed the last PR since I named the auth mechanism wrong and opened this instead. Sorry for the confusion and thanks for your patience.