### PR TITLE
Fix schema evalution scenario

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
-language: elixir
+os: linux
+dist: xenial
 
-notifications:
-  email: false
+language: elixir
 
 elixir:
   - 1.9.1
@@ -9,7 +9,7 @@ elixir:
 otp_release:
   - 22.0
 
-matrix:
+jobs:
   include:
     - elixir: "1.6"
       otp_release: "19.0"
@@ -31,3 +31,6 @@ cache:
     - priv/plts
     - _build
     - deps
+
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ This library supports convenient encoding and decoding of [Avro](https://avro.ap
 It can read the Avro schema from local files or the [Confluent® Schema
 Registry](https://www.confluent.io/confluent-schema-registry), caching
 data in memory for performance.
-
 It supports reading and writing data Kafka [wire format](https://docs.confluent.io/current/schema-registry/serializer-formatter.html#wire-format)
 prefix and from [Object Container Files](https://avro.apache.org/docs/1.8.1/spec.html#Object+Container+Files)
 formats. And has [Inter-Schema references](https://github.com/Strech/avrora/wiki/Inter-Schema-references) feature.
@@ -51,12 +50,16 @@ config :avrora,
 
 - `registry_url` - URL for the Confluent Schema Registry, default `nil`
 - `schemas_path` - Base path for locally stored schema files, default `./priv/schemas`
-- `names_cache_ttl` - Time in ms to cache schemas by name in memory, default `300_000`.
+- `names_cache_ttl` - Time in ms to cache schemas by name in memory, default
+  `:infinity` (since [v0.10.0](https://github.com/Strech/avrora/releases/tag/v0.10.0))
 
-Set `names_cache_ttl` to `:infinity` to cache forever. This is safe when
-schemas are resolved in the Schema Registry by numeric id or **versioned** name, as
-it is unique. If the schema is resolved by name, then someone may update the
-schema, so the TTL ensures that it will be reloaded to use the latest version.
+Set `names_cache_ttl` to `:infinity` will cache forever (no more disk reads will
+happen). This is safe when schemas are resolved in the Schema Registry by
+numeric id or **versioned** name, as it is unique. If you need to reload schema
+from the disk periodically, TTL different from `:infinity` ensures that.
+
+If the schema is resolved by name it will be always overwritten with the latest
+schema received from Schema Registry (this is a new behavior since [v0.10.0](https://github.com/Strech/avrora/releases/tag/v0.10.0)).
 
 ## Start cache process
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Configure the library in `config/config.exs`:
 config :avrora,
   registry_url: "http://localhost:8081",
   schemas_path: Path.expand("./priv/schemas"),
-  names_cache_ttl: :timer.minutes(5)
+  names_cache_ttl: :timer.minutes(5) # if you want periodic disk reads
 ```
 
 - `registry_url` - URL for the Confluent Schema Registry, default `nil`

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![Hex pm](https://img.shields.io/hexpm/v/avrora.svg?style=for-the-badge)](https://hex.pm/packages/avrora)
 [![Hex Docs](https://img.shields.io/badge/api-docs-blue.svg?style=for-the-badge)](https://hexdocs.pm/avrora)
-[![Build Status](https://img.shields.io/travis/Strech/avrora?style=for-the-badge)](https://travis-ci.org/Strech/avrora)
+[![Build Status](https://img.shields.io/travis/Strech/avrora/master?style=for-the-badge)](https://travis-ci.org/Strech/avrora)
 
 </span>
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -3,6 +3,6 @@ use Mix.Config
 config :avrora,
   schemas_path: Path.expand("./test/fixtures/schemas"),
   registry_url: nil,
-  names_cache_ttl: :timer.seconds(30)
+  names_cache_ttl: :infinity
 
 config :logger, :console, format: "$time $metadata[$level] $levelpad$message\n"

--- a/lib/avrora/config.ex
+++ b/lib/avrora/config.ex
@@ -6,7 +6,7 @@ defmodule Avrora.Config do
 
       * `schemas_path` path to local schema files, default ./priv/schemas
       * `registry_url` URL for Confluent Schema Registry, default nil
-      * `names_cache_ttl` duration to cache global schema names millisecods, default 300_000
+      * `names_cache_ttl` duration to cache global schema names millisecods, default :infinity
 
   ## Module configuration:
 
@@ -24,7 +24,7 @@ defmodule Avrora.Config do
   def registry_url, do: get_env(:registry_url, nil)
 
   @doc false
-  def names_cache_ttl, do: get_env(:names_cache_ttl, :timer.minutes(5))
+  def names_cache_ttl, do: get_env(:names_cache_ttl, :infinity)
 
   @doc false
   def file_storage, do: get_env(:file_storage, Avrora.Storage.File)

--- a/test/avrora/encoder_test.exs
+++ b/test/avrora/encoder_test.exs
@@ -82,8 +82,9 @@ defmodule Avrora.EncoderTest do
       end)
 
       Avrora.Storage.RegistryMock
-      |> expect(:get, fn key ->
+      |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
+        assert value == payment_json_schema()
 
         {:error, :unconfigured_registry_url}
       end)
@@ -102,7 +103,7 @@ defmodule Avrora.EncoderTest do
     end
 
     test "when payload was encoded without magic byte and registry is configured" do
-      payment_payment_schema_with_id_and_version = payment_payment_schema_with_id_and_version()
+      payment_schema_with_id = payment_schema_with_id()
 
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
@@ -111,14 +112,14 @@ defmodule Avrora.EncoderTest do
         {:ok, nil}
       end)
       |> expect(:put, fn key, value ->
-        assert key == "io.confluent.Payment:3"
-        assert value == payment_payment_schema_with_id_and_version
+        assert key == 42
+        assert value == payment_schema_with_id
 
         {:ok, value}
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == payment_payment_schema_with_id_and_version
+        assert value == payment_schema_with_id
 
         {:ok, value}
       end)
@@ -128,18 +129,20 @@ defmodule Avrora.EncoderTest do
 
         {:ok, :infinity}
       end)
-      |> expect(:put, fn key, value ->
-        assert key == 42
-        assert value == payment_payment_schema_with_id_and_version
 
-        {:ok, value}
-      end)
-
-      Avrora.Storage.RegistryMock
+      Avrora.Storage.FileMock
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, payment_payment_schema_with_id_and_version}
+        {:ok, payment_schema()}
+      end)
+
+      Avrora.Storage.RegistryMock
+      |> expect(:put, fn key, value ->
+        assert key == "io.confluent.Payment"
+        assert value == payment_json_schema()
+
+        {:ok, payment_schema_with_id}
       end)
 
       {:ok, decoded} =
@@ -157,8 +160,6 @@ defmodule Avrora.EncoderTest do
 
         {:ok, nil}
       end)
-
-      Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
@@ -177,8 +178,9 @@ defmodule Avrora.EncoderTest do
 
         {:error, :unconfigured_registry_url}
       end)
-      |> expect(:get, fn key ->
+      |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
+        assert value == payment_json_schema()
 
         {:error, :unconfigured_registry_url}
       end)
@@ -247,8 +249,9 @@ defmodule Avrora.EncoderTest do
       end)
 
       Avrora.Storage.RegistryMock
-      |> expect(:get, fn key ->
+      |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
+        assert value == payment_json_schema()
 
         {:error, :unconfigured_registry_url}
       end)
@@ -300,8 +303,9 @@ defmodule Avrora.EncoderTest do
       end)
 
       Avrora.Storage.RegistryMock
-      |> expect(:get, fn key ->
+      |> expect(:put, fn key, value ->
         assert key == "io.confluent.Messenger"
+        assert value == messenger_json_schema_with_local_reference()
 
         {:error, :unconfigured_registry_url}
       end)
@@ -341,8 +345,9 @@ defmodule Avrora.EncoderTest do
       end)
 
       Avrora.Storage.RegistryMock
-      |> expect(:get, fn key ->
+      |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
+        assert value == payment_json_schema()
 
         {:error, :unconfigured_registry_url}
       end)
@@ -375,8 +380,9 @@ defmodule Avrora.EncoderTest do
       end)
 
       Avrora.Storage.RegistryMock
-      |> expect(:get, fn key ->
+      |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
+        assert value == payment_json_schema()
 
         {:error, :unconfigured_registry_url}
       end)
@@ -395,7 +401,7 @@ defmodule Avrora.EncoderTest do
     end
 
     test "when registry is configured and schema is found, but format is given explicitly" do
-      payment_payment_schema_with_id_and_version = payment_payment_schema_with_id_and_version()
+      payment_schema_with_id = payment_schema_with_id()
 
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
@@ -404,14 +410,14 @@ defmodule Avrora.EncoderTest do
         {:ok, nil}
       end)
       |> expect(:put, fn key, value ->
-        assert key == "io.confluent.Payment:3"
-        assert value == payment_payment_schema_with_id_and_version
+        assert key == 42
+        assert value == payment_schema_with_id
 
         {:ok, value}
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
-        assert value == payment_payment_schema_with_id_and_version
+        assert value == payment_schema_with_id
 
         {:ok, value}
       end)
@@ -421,18 +427,20 @@ defmodule Avrora.EncoderTest do
 
         {:ok, :infinity}
       end)
-      |> expect(:put, fn key, value ->
-        assert key == 42
-        assert value == payment_payment_schema_with_id_and_version
 
-        {:ok, value}
-      end)
-
-      Avrora.Storage.RegistryMock
+      Avrora.Storage.FileMock
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, payment_payment_schema_with_id_and_version}
+        {:ok, payment_schema()}
+      end)
+
+      Avrora.Storage.RegistryMock
+      |> expect(:put, fn key, value ->
+        assert key == "io.confluent.Payment"
+        assert value == payment_json_schema()
+
+        {:ok, payment_schema_with_id}
       end)
 
       {:ok, encoded} =
@@ -441,15 +449,20 @@ defmodule Avrora.EncoderTest do
       assert is_payment_ocf(encoded)
     end
 
-    test "when registry is configured, but schema not found" do
+    test "when registry is configured and schema not found (same as found)" do
       payment_schema_with_id = payment_schema_with_id()
-      payment_schema = payment_schema()
 
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
         {:ok, nil}
+      end)
+      |> expect(:put, fn key, value ->
+        assert key == 42
+        assert value == payment_schema_with_id
+
+        {:ok, value}
       end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
@@ -463,19 +476,8 @@ defmodule Avrora.EncoderTest do
 
         {:ok, :infinity}
       end)
-      |> expect(:put, fn key, value ->
-        assert key == 42
-        assert value == payment_schema_with_id
-
-        {:ok, value}
-      end)
 
       Avrora.Storage.RegistryMock
-      |> expect(:get, fn key ->
-        assert key == "io.confluent.Payment"
-
-        {:error, :unknown_subject}
-      end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
         assert value == payment_json_schema()
@@ -487,52 +489,7 @@ defmodule Avrora.EncoderTest do
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
-        {:ok, payment_schema}
-      end)
-
-      {:ok, encoded} = Encoder.encode(payment_payload(), schema_name: "io.confluent.Payment")
-      assert payment_registry_message() == encoded
-    end
-
-    test "when registry is configured and schema was found" do
-      payment_payment_schema_with_id_and_version = payment_payment_schema_with_id_and_version()
-
-      Avrora.Storage.MemoryMock
-      |> expect(:get, fn key ->
-        assert key == "io.confluent.Payment"
-
-        {:ok, nil}
-      end)
-      |> expect(:put, fn key, value ->
-        assert key == "io.confluent.Payment:3"
-        assert value == payment_payment_schema_with_id_and_version
-
-        {:ok, value}
-      end)
-      |> expect(:put, fn key, value ->
-        assert key == "io.confluent.Payment"
-        assert value == payment_payment_schema_with_id_and_version
-
-        {:ok, value}
-      end)
-      |> expect(:expire, fn key, ttl ->
-        assert key == "io.confluent.Payment"
-        assert ttl == :infinity
-
-        {:ok, :infinity}
-      end)
-      |> expect(:put, fn key, value ->
-        assert key == 42
-        assert value == payment_payment_schema_with_id_and_version
-
-        {:ok, value}
-      end)
-
-      Avrora.Storage.RegistryMock
-      |> expect(:get, fn key ->
-        assert key == "io.confluent.Payment"
-
-        {:ok, payment_payment_schema_with_id_and_version}
+        {:ok, payment_schema()}
       end)
 
       {:ok, encoded} = Encoder.encode(payment_payload(), schema_name: "io.confluent.Payment")
@@ -556,8 +513,9 @@ defmodule Avrora.EncoderTest do
       end)
 
       Avrora.Storage.RegistryMock
-      |> expect(:get, fn key ->
+      |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
+        assert value == payment_json_schema()
 
         {:error, :unconfigured_registry_url}
       end)
@@ -600,8 +558,9 @@ defmodule Avrora.EncoderTest do
       end)
 
       Avrora.Storage.RegistryMock
-      |> expect(:get, fn key ->
+      |> expect(:put, fn key, value ->
         assert key == "io.confluent.Messenger"
+        assert value == messenger_json_schema_with_local_reference()
 
         {:error, :unconfigured_registry_url}
       end)
@@ -671,11 +630,6 @@ defmodule Avrora.EncoderTest do
     %{schema | id: nil, version: nil}
   end
 
-  defp payment_payment_schema_with_id_and_version do
-    {:ok, schema} = Schema.parse(payment_json_schema())
-    %{schema | id: 42, version: 3}
-  end
-
   defp payment_schema_with_id do
     {:ok, schema} = Schema.parse(payment_json_schema())
     %{schema | id: 42, version: nil}
@@ -688,6 +642,10 @@ defmodule Avrora.EncoderTest do
 
   defp messenger_json_schema do
     ~s({"namespace":"io.confluent","name":"Messenger","type":"record","fields":[{"name":"inbox","type":{"type":"array","items":{"type":"record","name":"Message","fields":[{"name":"text","type":"string"}]}}},{"name":"archive","type":{"type":"array","items":"io.confluent.Message"}}]})
+  end
+
+  defp messenger_json_schema_with_local_reference do
+    ~s({"namespace":"io.confluent","name":"Messenger","type":"record","fields":[{"name":"inbox","type":{"type":"array","items":{"name":"Message","type":"record","fields":[{"name":"text","type":"string"}]}}},{"name":"archive","type":{"type":"array","items":"Message"}}]})
   end
 
   defp payment_json_schema do

--- a/test/avrora/resolver_test.exs
+++ b/test/avrora/resolver_test.exs
@@ -242,54 +242,6 @@ defmodule Avrora.ResolverTest do
     end
 
     test "when schema name is given and it was not found in a memory, but registry" do
-      schema_with_id_and_version = schema_with_id_and_version()
-
-      Avrora.Storage.MemoryMock
-      |> expect(:get, fn key ->
-        assert key == "io.confluent.Payment"
-
-        {:ok, nil}
-      end)
-      |> expect(:put, fn key, value ->
-        assert key == "io.confluent.Payment:3"
-        assert value == schema_with_id_and_version
-
-        {:ok, value}
-      end)
-      |> expect(:put, fn key, value ->
-        assert key == "io.confluent.Payment"
-        assert value == schema_with_id_and_version
-
-        {:ok, value}
-      end)
-      |> expect(:expire, fn key, ttl ->
-        assert key == "io.confluent.Payment"
-        assert ttl == :infinity
-
-        {:ok, :infinity}
-      end)
-      |> expect(:put, fn key, value ->
-        assert key == 42
-        assert value == schema_with_id_and_version
-
-        {:ok, value}
-      end)
-
-      Avrora.Storage.RegistryMock
-      |> expect(:get, fn key ->
-        assert key == "io.confluent.Payment"
-
-        {:ok, schema_with_id_and_version}
-      end)
-
-      {:ok, schema} = Resolver.resolve("io.confluent.Payment")
-
-      assert schema.id == 42
-      assert schema.version == 3
-      assert schema.full_name == "io.confluent.Payment"
-    end
-
-    test "when schema name is given and it was not found in a memory and in a registry" do
       schema_with_id = schema_with_id()
       schema_without_id_and_version = schema_without_id_and_version()
 
@@ -300,6 +252,12 @@ defmodule Avrora.ResolverTest do
         {:ok, nil}
       end)
       |> expect(:put, fn key, value ->
+        assert key == 1
+        assert value == schema_with_id
+
+        {:ok, value}
+      end)
+      |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
         assert value == schema_with_id
 
@@ -311,31 +269,20 @@ defmodule Avrora.ResolverTest do
 
         {:ok, :infinity}
       end)
-      |> expect(:put, fn key, value ->
-        assert key == 1
-        assert value == schema_with_id
-
-        {:ok, value}
-      end)
-
-      Avrora.Storage.RegistryMock
-      |> expect(:get, fn key ->
-        assert key == "io.confluent.Payment"
-
-        {:error, :unknown_subject}
-      end)
-      |> expect(:put, fn key, value ->
-        assert key == "io.confluent.Payment"
-        assert value == json_schema()
-
-        {:ok, schema_with_id}
-      end)
 
       Avrora.Storage.FileMock
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
         {:ok, schema_without_id_and_version}
+      end)
+
+      Avrora.Storage.RegistryMock
+      |> expect(:put, fn key, value ->
+        assert key == "io.confluent.Payment"
+        assert value == json_schema()
+
+        {:ok, schema_with_id}
       end)
 
       {:ok, schema} = Resolver.resolve("io.confluent.Payment")
@@ -351,6 +298,13 @@ defmodule Avrora.ResolverTest do
         assert key == "io.confluent.Payment:3"
 
         {:ok, nil}
+      end)
+
+      Avrora.Storage.FileMock
+      |> expect(:get, fn key ->
+        assert key == "io.confluent.Payment:3"
+
+        {:ok, schema_without_id_and_version()}
       end)
 
       Avrora.Storage.RegistryMock
@@ -379,18 +333,19 @@ defmodule Avrora.ResolverTest do
         {:ok, value}
       end)
 
-      Avrora.Storage.RegistryMock
-      |> expect(:get, fn key ->
-        assert key == "io.confluent.Payment"
-
-        {:error, :unconfigured_registry_url}
-      end)
-
       Avrora.Storage.FileMock
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment"
 
         {:ok, schema_without_id_and_version}
+      end)
+
+      Avrora.Storage.RegistryMock
+      |> expect(:put, fn key, value ->
+        assert key == "io.confluent.Payment"
+        assert value == json_schema()
+
+        {:error, :unconfigured_registry_url}
       end)
 
       {:ok, schema} = Resolver.resolve("io.confluent.Payment")
@@ -416,18 +371,18 @@ defmodule Avrora.ResolverTest do
         {:ok, value}
       end)
 
-      Avrora.Storage.RegistryMock
-      |> expect(:get, fn key ->
-        assert key == "io.confluent.Payment:3"
-
-        {:error, :unconfigured_registry_url}
-      end)
-
       Avrora.Storage.FileMock
       |> expect(:get, fn key ->
         assert key == "io.confluent.Payment:3"
 
         {:ok, schema_without_id_and_version}
+      end)
+
+      Avrora.Storage.RegistryMock
+      |> expect(:get, fn key ->
+        assert key == "io.confluent.Payment:3"
+
+        {:error, :unconfigured_registry_url}
       end)
 
       {:ok, schema} = Resolver.resolve("io.confluent.Payment:3")
@@ -447,7 +402,7 @@ defmodule Avrora.ResolverTest do
         {:ok, nil}
       end)
       |> expect(:put, fn key, value ->
-        assert key == "io.confluent.Payment:3"
+        assert key == 42
         assert value == schema_with_id_and_version
 
         {:ok, value}
@@ -465,10 +420,17 @@ defmodule Avrora.ResolverTest do
         {:ok, :infinity}
       end)
       |> expect(:put, fn key, value ->
-        assert key == 42
+        assert key == "io.confluent.Payment:3"
         assert value == schema_with_id_and_version
 
         {:ok, value}
+      end)
+
+      Avrora.Storage.FileMock
+      |> expect(:get, fn key ->
+        assert key == "io.confluent.Payment:3"
+
+        {:ok, schema_without_id_and_version()}
       end)
 
       Avrora.Storage.RegistryMock

--- a/test/avrora/resolver_test.exs
+++ b/test/avrora/resolver_test.exs
@@ -60,11 +60,6 @@ defmodule Avrora.ResolverTest do
 
         {:error, :unknown_subject}
       end)
-      |> expect(:get, fn key ->
-        assert key == "io.confluent.Payment"
-
-        {:error, :unknown_subject}
-      end)
       |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
         assert value == json_schema()
@@ -106,11 +101,6 @@ defmodule Avrora.ResolverTest do
 
         {:error, :unknown_subject}
       end)
-      |> expect(:get, fn key ->
-        assert key == "io.confluent.Payment"
-
-        {:error, :unknown_subject}
-      end)
 
       Avrora.Storage.FileMock
       |> expect(:get, fn key ->
@@ -127,7 +117,7 @@ defmodule Avrora.ResolverTest do
       assert output =~ "fail to resolve schema by identifier"
     end
 
-    test "when registry is not configured and was not found in memory" do
+    test "when registry is not configured and schema was not found in memory" do
       schema_without_id_and_version = schema_without_id_and_version()
 
       Avrora.Storage.MemoryMock
@@ -154,8 +144,9 @@ defmodule Avrora.ResolverTest do
 
         {:error, :unconfigured_registry_url}
       end)
-      |> expect(:get, fn key ->
+      |> expect(:put, fn key, value ->
         assert key == "io.confluent.Payment"
+        assert value == json_schema()
 
         {:error, :unconfigured_registry_url}
       end)


### PR DESCRIPTION
### Changes

- [x] Generic names cache TTL change its defaults to `:infinity` **breaking**
- [x] Latest schema versions overriding Generic names **breaking**
- [x] Schema name resolution reads schema file when nothing found in memory
- [x] Schema names resolved not from the memory get written into the registry first

---

### TODO

- [x] Update the readme

Closes #27 