### PR TITLE
Managing schema registry's schema references

### DIFF
--- a/lib/avrora/storage/registry.ex
+++ b/lib/avrora/storage/registry.ex
@@ -94,17 +94,17 @@ defmodule Avrora.Storage.Registry do
   def configured?, do: !is_nil(registry_url())
 
   defp csr_references_lookup_function(response) do
-    with {:ok, csr_references} <- Map.fetch(response, "references") do
-      references = Enum.reduce(csr_references, %{}, fn(cr, map) ->
-        {:ok, schema_map} = get(cr["subject"])
-        Map.put(map, schema_map.full_name, schema_map.json)
-      end )
+    case Map.fetch(response, "references") do
+      {:ok, csr_references} ->
+        references = Enum.reduce(csr_references, %{}, fn(cr, map) ->
+          {:ok, schema_map} = get(cr["subject"])
+          Map.put(map, schema_map.full_name, schema_map.json)
+        end )
 
-      fn(r) ->
-        json_schema = Map.get(references, r)
-        {:ok, json_schema}
-      end
-    else
+        fn(r) ->
+          json_schema = Map.get(references, r)
+          {:ok, json_schema}
+        end
       :error -> nil
     end
   end

--- a/test/avrora/storage/registry_test.exs
+++ b/test/avrora/storage/registry_test.exs
@@ -11,6 +11,48 @@ defmodule Avrora.Storage.RegistryTest do
   setup :support_config
 
   describe "get/1" do
+    test "when request by subject name of schema with reference without version was successful" do
+      Avrora.HTTPClientMock
+      |> expect(:get, fn url, options ->
+        assert url == "http://reg.loc/subjects/io.confluent.Account/versions/latest"
+        assert options == []
+
+        {
+          :ok,
+          %{
+            "subject" => "io.confluent.Account",
+            "id" => 43,
+            "version" => 1,
+            "schema" => json_schema_with_reference(),
+            "references" => [%{"name" => "io.confluent.User", "subject" => "io.confluent.User", "version" => 1}]
+          }
+        }
+      end)
+
+      Avrora.HTTPClientMock
+      |> expect(:get, fn url, options ->
+        assert url == "http://reg.loc/subjects/io.confluent.User/versions/latest"
+        assert options == []
+
+        {
+          :ok,
+          %{
+            "subject" => "io.confluent.User",
+            "id" => 44,
+            "version" => 1,
+            "schema" => json_schema_referenced()
+          }
+        }
+      end)
+
+      {:ok, schema} = Registry.get("io.confluent.Account")
+
+      assert schema.id == 43
+      assert schema.version == 1
+      assert schema.full_name == "io.confluent.Account"
+      assert schema.json == json_schema_with_reference_denormalized()
+    end
+
     test "when request by subject name without version was successful" do
       Avrora.HTTPClientMock
       |> expect(:get, fn url, options ->
@@ -221,4 +263,18 @@ defmodule Avrora.Storage.RegistryTest do
   defp json_schema do
     ~s({"namespace":"io.confluent","type":"record","name":"Payment","fields":[{"name":"id","type":"string"},{"name":"amount","type":"double"}]})
   end
+
+  defp json_schema_with_reference do
+    ~s({"namespace":"io.confluent","type":"record","name":"Account","fields":[{"name":"id","type":"string"},{"name":"user","type":"User"}]})
+  end
+
+  defp json_schema_with_reference_denormalized do
+    nested_schema = ~s({"name":"User","type":"record","fields":[{"name":"id","type":"string"},{"name":"username","type":"string"}]})
+    ~s({"namespace":"io.confluent","name":"Account","type":"record","fields":[{"name":"id","type":"string"},{"name":"user","type":#{nested_schema}}]})
+  end
+
+  defp json_schema_referenced do
+    ~s({"namespace":"io.confluent","type":"record","name":"User","fields":[{"name":"id","type":"string"},{"name":"username","type":"string"}]})
+  end
+
 end


### PR DESCRIPTION
This PR enables Avro schema parsing with new schema registry's schema references feature, introducing a dedicated lookup function for references got from CSR.
Changes in this PR comes from the discussion of the deprecated #49  pull request.

cc @Strech 