### PR TITLE
adds decode/3 with format option

### DIFF
--- a/lib/avrora/encoder.ex
+++ b/lib/avrora/encoder.ex
@@ -63,7 +63,8 @@ defmodule Avrora.Encoder do
       {:ok, %{"id" => "00000000-0000-0000-0000-000000000000", "amount" => 15.99}}
   """
   @spec decode(binary(), schema_name: String.t()) :: {:ok, map() | list(map())} | {:error, term()}
-  def decode(payload, schema_name: schema_name) when is_binary(payload) do
+  def decode(payload, schema_name: schema_name)
+      when is_binary(payload) do
     with {:ok, schema_name} <- Name.parse(schema_name) do
       unless is_nil(schema_name.version) do
         Logger.warn(
@@ -76,6 +77,66 @@ defmodule Avrora.Encoder do
       codec =
         [Codec.SchemaRegistry, Codec.ObjectContainerFile, Codec.Plain]
         |> Enum.find(& &1.is_decodable(payload))
+
+      codec.decode(payload, schema: schema)
+    end
+  end
+
+  @doc """
+  Decode binary Avro message, loading schema from local file or Schema Registry.
+
+  The `:format` argument defines the decoder:
+
+  * `:guess` - Use `:registry` if possible, otherwise use `:ocf` (default)
+  * `:plain` - Just return Avro binary data, with no header or embedded schema
+  * `:ocf` - Use [Object Container File]https://avro.apache.org/docs/1.8.1/spec.html#Object+Container+Files)
+    format, embedding the full schema with the data
+  * `:registry` - Write data with Confluent Schema Registry
+    [Wire Format](https://docs.confluent.io/current/schema-registry/serializer-formatter.html#wire-format),
+    which prefixes the data with the schema id
+
+  ## Examples
+
+      ...> payload = <<72, 48, 48, 48, 48, 48, 48, 48, 48, 45, 48, 48, 48, 48, 45,
+      48, 48, 48, 48, 45, 48, 48, 48, 48, 45, 48, 48, 48, 48, 48, 48, 48, 48, 48,
+      48, 48, 48, 123, 20, 174, 71, 225, 250, 47, 64>>
+      ...> Avrora.Encoder.decode(payload, schema_name: "io.confluent.Payment")
+      {:ok, %{"id" => "00000000-0000-0000-0000-000000000000", "amount" => 15.99}}
+  """
+  @spec decode(binary(), schema_name: String.t(), format: :guess | :registry | :ocf | :plain) ::
+          {:ok, map() | list(map())} | {:error, term()}
+  def decode(payload, schema_name: schema_name, format: format)
+      when is_binary(payload) do
+    [format: format, schema_name: schema_name] =
+      Keyword.merge([format: :guess, schema_name: nil], format: format, schema_name: schema_name)
+
+    with {:ok, schema_name} <- Name.parse(schema_name) do
+      unless is_nil(schema_name.version) do
+        Logger.warn(
+          "decoding message with schema version is not supported, `#{schema_name.name}` used instead"
+        )
+      end
+
+      schema = %Schema{full_name: schema_name.name}
+
+      codec =
+        case format do
+          :guess ->
+            [Codec.SchemaRegistry, Codec.ObjectContainerFile, Codec.Plain]
+            |> Enum.find(& &1.is_decodable(payload))
+
+          :registry ->
+            Codec.SchemaRegistry
+
+          :ocf ->
+            Codec.ObjectContainerFile
+
+          :plain ->
+            Codec.Plain
+
+          _ ->
+            {:error, :unknown_format}
+        end
 
       codec.decode(payload, schema: schema)
     end

--- a/test/avrora/encoder_test.exs
+++ b/test/avrora/encoder_test.exs
@@ -402,6 +402,44 @@ defmodule Avrora.EncoderTest do
     end
   end
 
+  test "when decoding plain message that starts with what looks like a magic byte" do
+     schema_name = "io.confluent.numeric_transfer"
+     numeric_transfer_schema = numeric_transfer_schema()
+
+      Avrora.Storage.MemoryMock
+      |> expect(:get, fn key ->
+        assert key == "io.confluent.numeric_transfer"
+
+        {:ok, nil}
+      end)
+      |> expect(:put, fn key, value ->
+        assert key == "io.confluent.numeric_transfer"
+        assert value == numeric_transfer_schema
+
+        {:ok, value}
+      end)
+
+      Avrora.Storage.RegistryMock
+      |> expect(:put, fn key, value ->
+        assert key == "io.confluent.numeric_transfer"
+        assert value == numeric_transfer_json_schema()
+
+        {:error, :unconfigured_registry_url}
+      end)
+
+      Avrora.Storage.FileMock
+      |> expect(:get, fn key ->
+        assert key == "io.confluent.numeric_transfer"
+
+        {:ok, numeric_transfer_schema}
+      end)
+
+      assert {:ok, decoded} = Avrora.decode(numeric_transfer_plain_message_0(), schema_name: schema_name, format: :plain)
+
+      assert decoded == %{ "link_is_enabled" => false, "updated_at" => 1_586_632_500, "updated_by_id" => 1_00 }
+  end
+
+
   describe "encode/2" do
     test "when registry is not configured" do
       payment_schema = payment_schema()
@@ -706,6 +744,10 @@ defmodule Avrora.EncoderTest do
       119, 32, 97, 114, 101, 32, 121, 111, 117, 63, 0>>
   end
 
+  defp numeric_transfer_plain_message_0 do
+    <<0, 232, 220, 144, 233, 11, 200, 1>>
+  end
+
   defp payment_schema do
     {:ok, schema} = Schema.parse(payment_json_schema())
     %{schema | id: nil, version: nil}
@@ -721,6 +763,11 @@ defmodule Avrora.EncoderTest do
     %{schema | id: nil, version: nil}
   end
 
+  defp numeric_transfer_schema do
+    {:ok, schema} = Schema.parse(numeric_transfer_json_schema())
+    %{schema | id: nil, version: nil}
+  end
+
   defp messenger_json_schema do
     ~s({"namespace":"io.confluent","name":"Messenger","type":"record","fields":[{"name":"inbox","type":{"type":"array","items":{"type":"record","name":"Message","fields":[{"name":"text","type":"string"}]}}},{"name":"archive","type":{"type":"array","items":"io.confluent.Message"}}]})
   end
@@ -731,5 +778,9 @@ defmodule Avrora.EncoderTest do
 
   defp payment_json_schema do
     ~s({"namespace":"io.confluent","name":"Payment","type":"record","fields":[{"name":"id","type":"string"},{"name":"amount","type":"double"}]})
+  end
+
+  defp numeric_transfer_json_schema do
+    ~s({"namespace":"io.confluent","name":"numeric_transfer","type":"record","fields":[{"name":"link_is_enabled","type":"boolean"},{"name":"updated_at","type":"int"},{"name":"updated_by_id","type":"int"}]})
   end
 end

--- a/test/avrora/encoder_test.exs
+++ b/test/avrora/encoder_test.exs
@@ -403,42 +403,46 @@ defmodule Avrora.EncoderTest do
   end
 
   test "when decoding plain message that starts with what looks like a magic byte" do
-     schema_name = "io.confluent.numeric_transfer"
-     numeric_transfer_schema = numeric_transfer_schema()
+    schema_name = "io.confluent.numeric_transfer"
+    numeric_transfer_schema = numeric_transfer_schema()
 
-      Avrora.Storage.MemoryMock
-      |> expect(:get, fn key ->
-        assert key == "io.confluent.numeric_transfer"
+    Avrora.Storage.MemoryMock
+    |> expect(:get, fn key ->
+      assert key == "io.confluent.numeric_transfer"
 
-        {:ok, nil}
-      end)
-      |> expect(:put, fn key, value ->
-        assert key == "io.confluent.numeric_transfer"
-        assert value == numeric_transfer_schema
+      {:ok, nil}
+    end)
+    |> expect(:put, fn key, value ->
+      assert key == "io.confluent.numeric_transfer"
+      assert value == numeric_transfer_schema
 
-        {:ok, value}
-      end)
+      {:ok, value}
+    end)
 
-      Avrora.Storage.RegistryMock
-      |> expect(:put, fn key, value ->
-        assert key == "io.confluent.numeric_transfer"
-        assert value == numeric_transfer_json_schema()
+    Avrora.Storage.RegistryMock
+    |> expect(:put, fn key, value ->
+      assert key == "io.confluent.numeric_transfer"
+      assert value == numeric_transfer_json_schema()
 
-        {:error, :unconfigured_registry_url}
-      end)
+      {:error, :unconfigured_registry_url}
+    end)
 
-      Avrora.Storage.FileMock
-      |> expect(:get, fn key ->
-        assert key == "io.confluent.numeric_transfer"
+    Avrora.Storage.FileMock
+    |> expect(:get, fn key ->
+      assert key == "io.confluent.numeric_transfer"
 
-        {:ok, numeric_transfer_schema}
-      end)
+      {:ok, numeric_transfer_schema}
+    end)
 
-      assert {:ok, decoded} = Avrora.decode(numeric_transfer_plain_message_0(), schema_name: schema_name, format: :plain)
+    assert {:ok, decoded} =
+             Avrora.decode(numeric_transfer_plain_message_0(), schema_name: schema_name)
 
-      assert decoded == %{ "link_is_enabled" => false, "updated_at" => 1_586_632_500, "updated_by_id" => 1_00 }
+    assert decoded == %{
+             "link_is_enabled" => false,
+             "updated_at" => 1_586_632_500,
+             "updated_by_id" => 1_00
+           }
   end
-
 
   describe "encode/2" do
     test "when registry is not configured" do


### PR DESCRIPTION
This fixes a bug where for decoding a schema that was encoded with `:plain` format.

If the encoded message starts with the magic byte (0x00) due to the data that was encoded, the wrong codec is selected by
https://github.com/Strech/avrora/blob/master/lib/avrora/encoder.ex#L76
when decoding it later. 
This causes the decoding to fail sporadically dependent on the encoded data. 

I propose to fix this by including an optional `format` argument to the `decode` function. 

Example: New test case that broke before adding the `format: plain` parameter
```shell
  1) test when decoding plain message that starts with what looks like a magic byte (Avrora.EncoderTest)
     test/avrora/encoder_test.exs:405
     Assertion with == failed
     code:  assert key == "io.confluent.numeric_transfer"
     left:  3906769129
     right: "io.confluent.numeric_transfer"
     stacktrace:
       test/avrora/encoder_test.exs:411: anonymous fn/1 in Avrora.EncoderTest."test when decoding plain message that starts with what looks like a magic byte"/1
       (avrora 0.17.0) lib/avrora/resolver.ex:47: Avrora.Resolver.resolve/1
       (avrora 0.17.0) lib/avrora/resolver.ex:26: anonymous fn/1 in Avrora.Resolver.resolve_any/1
       (elixir 1.10.4) lib/stream.ex:572: anonymous fn/4 in Stream.map/2
       (elixir 1.10.4) lib/enum.ex:3686: Enumerable.List.reduce/3
       (elixir 1.10.4) lib/stream.ex:1609: Enumerable.Stream.do_each/4
       (elixir 1.10.4) lib/enum.ex:1027: Enum.find_value/3
       (avrora 0.17.0) lib/avrora/codec/schema_registry.ex:57: Avrora.Codec.SchemaRegistry.decode/2
       test/avrora/encoder_test.exs:437: (test)
```