### PR TITLE
adds decode/3 with format option

### DIFF
--- a/lib/avrora.ex
+++ b/lib/avrora.ex
@@ -6,6 +6,8 @@ defmodule Avrora do
   defdelegate decode(payload), to: Avrora.Encoder
   defdelegate encode(payload, opts), to: Avrora.Encoder
   defdelegate decode(payload, opts), to: Avrora.Encoder
+  defdelegate decode_plain(payload, opts), to: Avrora.Encoder
+  defdelegate encode_plain(payload, opts), to: Avrora.Encoder
   defdelegate extract_schema(payload), to: Avrora.Encoder
 
   def start_link(opts \\ []), do: Supervisor.start_link(__MODULE__, opts, name: __MODULE__)

--- a/lib/avrora/encoder.ex
+++ b/lib/avrora/encoder.ex
@@ -73,8 +73,7 @@ defmodule Avrora.Encoder do
         )
       end
 
-      schema = %Schema{full_name: schema_name.name}
-      Codec.Plain.decode(payload, schema: schema)
+      Codec.Plain.decode(payload, schema: %Schema{full_name: schema_name.name})
     end
   end
 
@@ -186,8 +185,7 @@ defmodule Avrora.Encoder do
         )
       end
 
-      schema = %Schema{full_name: schema_name.name}
-      Codec.Plain.encode(payload, schema: schema)
+      Codec.Plain.encode(payload, schema: %Schema{full_name: schema_name.name})
     end
   end
 end

--- a/lib/avrora/encoder.ex
+++ b/lib/avrora/encoder.ex
@@ -54,13 +54,10 @@ defmodule Avrora.Encoder do
   @doc """
   Decode binary Avro message with :plain format and given schema.
 
-  This is pulled out as a special function to work around :plain encoded binaries that,
-  due to their encoded data, start with the magic byte.
-
   ## Examples
 
       ...> payload = <<0, 232, 220, 144, 233, 11, 200, 1>>
-      ...> Avrora.Encoder.decode_plain(payload,"io.confluent.numeric_transfer")
+      ...> Avrora.Encoder.decode_plain(payload,"io.confluent.NumericTransfer")
       {:ok, %{ "link_is_enabled" => false, "updated_at" => 1_586_632_500, "updated_by_id" => 1_00 }
   """
   @spec decode_plain(binary(), schema_name: String.t()) ::
@@ -112,8 +109,7 @@ defmodule Avrora.Encoder do
 
   The `:format` argument controls output format:
 
-  * `:plain` - Just return Avro binary data, with no header or embedded schema.
-    Alternatively the encode_plain/2 function is equivalent
+  * `:plain` - Just return Avro binary data, with no header or embedded schema
   * `:ocf` - Use [Object Container File]https://avro.apache.org/docs/1.8.1/spec.html#Object+Container+Files)
     format, embedding the full schema with the data
   * `:registry` - Write data with Confluent Schema Registry
@@ -167,14 +163,10 @@ defmodule Avrora.Encoder do
   @doc """
   Encode binary Avro message with :plain format and given schema.
 
-  Retuns a plain Avro encoded message binary. This exists to mirror decode_plain/2,
-  which is necessary when decoding plain messages with a given schema due to the possibility of
-  a plain message starting with the magic byte, leading decode/2 to fail.
-
   ## Examples
 
       ...> payload = %{ "link_is_enabled" => false, "updated_at" => 1_586_632_500, "updated_by_id" => 1_00 }
-      ...> Avrora.Encoder.encode_plain(payload,"io.confluent.numeric_transfer")
+      ...> Avrora.Encoder.encode_plain(payload,"io.confluent.NumericTransfer")
       {:ok, <<0, 232, 220, 144, 233, 11, 200, 1>>}
   """
   def encode_plain(payload, schema_name: schema_name) when is_map(payload) do

--- a/test/avrora/encoder_test.exs
+++ b/test/avrora/encoder_test.exs
@@ -404,17 +404,17 @@ defmodule Avrora.EncoderTest do
 
   describe "decode_plain/2" do
     test "when decoding plain message that starts with what looks like a magic byte" do
-      schema_name = "io.confluent.numeric_transfer"
+      schema_name = "io.confluent.NumericTransfer"
       numeric_transfer_schema = numeric_transfer_schema()
 
       Avrora.Storage.MemoryMock
       |> expect(:get, fn key ->
-        assert key == "io.confluent.numeric_transfer"
+        assert key == "io.confluent.NumericTransfer"
 
         {:ok, nil}
       end)
       |> expect(:put, fn key, value ->
-        assert key == "io.confluent.numeric_transfer"
+        assert key == "io.confluent.NumericTransfer"
         assert value == numeric_transfer_schema
 
         {:ok, value}
@@ -422,7 +422,7 @@ defmodule Avrora.EncoderTest do
 
       Avrora.Storage.RegistryMock
       |> expect(:put, fn key, value ->
-        assert key == "io.confluent.numeric_transfer"
+        assert key == "io.confluent.NumericTransfer"
         assert value == numeric_transfer_json_schema()
 
         {:error, :unconfigured_registry_url}
@@ -430,15 +430,22 @@ defmodule Avrora.EncoderTest do
 
       Avrora.Storage.FileMock
       |> expect(:get, fn key ->
-        assert key == "io.confluent.numeric_transfer"
+        assert key == "io.confluent.NumericTransfer"
 
         {:ok, numeric_transfer_schema}
       end)
 
       {:ok, decoded} =
-        Avrora.decode_plain(numeric_transfer_plain_message_fake_magic_byte(), schema_name: schema_name)
+        Avrora.decode_plain(
+          numeric_transfer_plain_message_with_fake_magic_byte(),
+          schema_name: schema_name
+        )
 
-      assert decoded == %{"link_is_enabled" => false, "updated_at" => 1_586_632_500, "updated_by_id" => 1_00}
+      assert decoded == %{
+               "link_is_enabled" => false,
+               "updated_at" => 1_586_632_500,
+               "updated_by_id" => 1_00
+             }
     end
   end
 
@@ -746,7 +753,7 @@ defmodule Avrora.EncoderTest do
       119, 32, 97, 114, 101, 32, 121, 111, 117, 63, 0>>
   end
 
-  defp numeric_transfer_plain_message_0 do
+  defp numeric_transfer_plain_message_with_fake_magic_byte do
     <<0, 232, 220, 144, 233, 11, 200, 1>>
   end
 
@@ -783,6 +790,6 @@ defmodule Avrora.EncoderTest do
   end
 
   defp numeric_transfer_json_schema do
-    ~s({"namespace":"io.confluent","name":"numeric_transfer","type":"record","fields":[{"name":"link_is_enabled","type":"boolean"},{"name":"updated_at","type":"int"},{"name":"updated_by_id","type":"int"}]})
+    ~s({"namespace":"io.confluent","name":"NumericTransfer","type":"record","fields":[{"name":"link_is_enabled","type":"boolean"},{"name":"updated_at","type":"int"},{"name":"updated_by_id","type":"int"}]})
   end
 end

--- a/test/avrora/encoder_test.exs
+++ b/test/avrora/encoder_test.exs
@@ -435,17 +435,10 @@ defmodule Avrora.EncoderTest do
         {:ok, numeric_transfer_schema}
       end)
 
-      assert {:ok, decoded} =
-               Avrora.decode_plain(
-                 numeric_transfer_plain_message_0(),
-                 schema_name: schema_name
-               )
+      {:ok, decoded} =
+        Avrora.decode_plain(numeric_transfer_plain_message_fake_magic_byte(), schema_name: schema_name)
 
-      assert decoded == %{
-               "link_is_enabled" => false,
-               "updated_at" => 1_586_632_500,
-               "updated_by_id" => 1_00
-             }
+      assert decoded == %{"link_is_enabled" => false, "updated_at" => 1_586_632_500, "updated_by_id" => 1_00}
     end
   end
 

--- a/test/avrora/encoder_test.exs
+++ b/test/avrora/encoder_test.exs
@@ -402,6 +402,52 @@ defmodule Avrora.EncoderTest do
     end
   end
 
+  test "when decoding plain message that starts with what looks like a magic byte" do
+    schema_name = "io.confluent.numeric_transfer"
+    numeric_transfer_schema = numeric_transfer_schema()
+
+    Avrora.Storage.MemoryMock
+    |> expect(:get, fn key ->
+      assert key == "io.confluent.numeric_transfer"
+
+      {:ok, nil}
+    end)
+    |> expect(:put, fn key, value ->
+      assert key == "io.confluent.numeric_transfer"
+      assert value == numeric_transfer_schema
+
+      {:ok, value}
+    end)
+
+    Avrora.Storage.RegistryMock
+    |> expect(:put, fn key, value ->
+      assert key == "io.confluent.numeric_transfer"
+      assert value == numeric_transfer_json_schema()
+
+      {:error, :unconfigured_registry_url}
+    end)
+
+    Avrora.Storage.FileMock
+    |> expect(:get, fn key ->
+      assert key == "io.confluent.numeric_transfer"
+
+      {:ok, numeric_transfer_schema}
+    end)
+
+    assert {:ok, decoded} =
+             Avrora.decode(
+               numeric_transfer_plain_message_0(),
+               schema_name: schema_name,
+               format: :plain
+             )
+
+    assert decoded == %{
+             "link_is_enabled" => false,
+             "updated_at" => 1_586_632_500,
+             "updated_by_id" => 1_00
+           }
+  end
+
   describe "encode/2" do
     test "when registry is not configured" do
       payment_schema = payment_schema()
@@ -706,6 +752,10 @@ defmodule Avrora.EncoderTest do
       119, 32, 97, 114, 101, 32, 121, 111, 117, 63, 0>>
   end
 
+  defp numeric_transfer_plain_message_0 do
+    <<0, 232, 220, 144, 233, 11, 200, 1>>
+  end
+
   defp payment_schema do
     {:ok, schema} = Schema.parse(payment_json_schema())
     %{schema | id: nil, version: nil}
@@ -721,6 +771,11 @@ defmodule Avrora.EncoderTest do
     %{schema | id: nil, version: nil}
   end
 
+  defp numeric_transfer_schema do
+    {:ok, schema} = Schema.parse(numeric_transfer_json_schema())
+    %{schema | id: nil, version: nil}
+  end
+
   defp messenger_json_schema do
     ~s({"namespace":"io.confluent","name":"Messenger","type":"record","fields":[{"name":"inbox","type":{"type":"array","items":{"type":"record","name":"Message","fields":[{"name":"text","type":"string"}]}}},{"name":"archive","type":{"type":"array","items":"io.confluent.Message"}}]})
   end
@@ -731,5 +786,9 @@ defmodule Avrora.EncoderTest do
 
   defp payment_json_schema do
     ~s({"namespace":"io.confluent","name":"Payment","type":"record","fields":[{"name":"id","type":"string"},{"name":"amount","type":"double"}]})
+  end
+
+  defp numeric_transfer_json_schema do
+    ~s({"namespace":"io.confluent","name":"numeric_transfer","type":"record","fields":[{"name":"link_is_enabled","type":"boolean"},{"name":"updated_at","type":"int"},{"name":"updated_by_id","type":"int"}]})
   end
 end

--- a/test/avrora/encoder_test.exs
+++ b/test/avrora/encoder_test.exs
@@ -402,50 +402,51 @@ defmodule Avrora.EncoderTest do
     end
   end
 
-  test "when decoding plain message that starts with what looks like a magic byte" do
-    schema_name = "io.confluent.numeric_transfer"
-    numeric_transfer_schema = numeric_transfer_schema()
+  describe "decode_plain/2" do
+    test "when decoding plain message that starts with what looks like a magic byte" do
+      schema_name = "io.confluent.numeric_transfer"
+      numeric_transfer_schema = numeric_transfer_schema()
 
-    Avrora.Storage.MemoryMock
-    |> expect(:get, fn key ->
-      assert key == "io.confluent.numeric_transfer"
+      Avrora.Storage.MemoryMock
+      |> expect(:get, fn key ->
+        assert key == "io.confluent.numeric_transfer"
 
-      {:ok, nil}
-    end)
-    |> expect(:put, fn key, value ->
-      assert key == "io.confluent.numeric_transfer"
-      assert value == numeric_transfer_schema
+        {:ok, nil}
+      end)
+      |> expect(:put, fn key, value ->
+        assert key == "io.confluent.numeric_transfer"
+        assert value == numeric_transfer_schema
 
-      {:ok, value}
-    end)
+        {:ok, value}
+      end)
 
-    Avrora.Storage.RegistryMock
-    |> expect(:put, fn key, value ->
-      assert key == "io.confluent.numeric_transfer"
-      assert value == numeric_transfer_json_schema()
+      Avrora.Storage.RegistryMock
+      |> expect(:put, fn key, value ->
+        assert key == "io.confluent.numeric_transfer"
+        assert value == numeric_transfer_json_schema()
 
-      {:error, :unconfigured_registry_url}
-    end)
+        {:error, :unconfigured_registry_url}
+      end)
 
-    Avrora.Storage.FileMock
-    |> expect(:get, fn key ->
-      assert key == "io.confluent.numeric_transfer"
+      Avrora.Storage.FileMock
+      |> expect(:get, fn key ->
+        assert key == "io.confluent.numeric_transfer"
 
-      {:ok, numeric_transfer_schema}
-    end)
+        {:ok, numeric_transfer_schema}
+      end)
 
-    assert {:ok, decoded} =
-             Avrora.decode(
-               numeric_transfer_plain_message_0(),
-               schema_name: schema_name,
-               format: :plain
-             )
+      assert {:ok, decoded} =
+               Avrora.decode_plain(
+                 numeric_transfer_plain_message_0(),
+                 schema_name: schema_name
+               )
 
-    assert decoded == %{
-             "link_is_enabled" => false,
-             "updated_at" => 1_586_632_500,
-             "updated_by_id" => 1_00
-           }
+      assert decoded == %{
+               "link_is_enabled" => false,
+               "updated_at" => 1_586_632_500,
+               "updated_by_id" => 1_00
+             }
+    end
   end
 
   describe "encode/2" do

--- a/test/integration/lib/interfaces.ex
+++ b/test/integration/lib/interfaces.ex
@@ -35,6 +35,11 @@ defmodule Interfaces do
     end
 
     @doc false
+    def decode_plain_with_one_option do
+      Avrora.decode(<<2, 118>>, schema_name: "avrora.Record")
+    end
+
+    @doc false
     def encode_with_one_option do
       Avrora.encode(%{"k" => "v"}, schema_name: "avrora.Record")
     end
@@ -42,6 +47,11 @@ defmodule Interfaces do
     @doc false
     def encode_with_two_options do
       Avrora.encode(%{"k" => "v"}, schema_name: "avrora.Record", format: :plain)
+    end
+
+    # doc false
+    def encode_plain_with_one_option do
+      Avrora.encode_plain(%{"k" => "v"}, schema_name: "avrora.Record")
     end
   end
 end


### PR DESCRIPTION
This fixes a bug where decoding fails for a data that was encoded with a supplied `schema_name` and `:plain` format

If the encoded message starts with the magic byte (0x00) due to the data that was encoded, the wrong codec is selected by
https://github.com/Strech/avrora/blob/master/lib/avrora/encoder.ex#L76
when decoding it later. 
This causes the decoding to fail sporadically dependent on the encoded data. 

I propose to fix this by including an optional `format` argument to the `decode` function. 

Example: New test case that broke before adding the `format: plain` parameter
```shell
  1) test when decoding plain message that starts with what looks like a magic byte (Avrora.EncoderTest)
     test/avrora/encoder_test.exs:405
     Assertion with == failed
     code:  assert key == "io.confluent.numeric_transfer"
     left:  3906769129
     right: "io.confluent.numeric_transfer"
     stacktrace:
       test/avrora/encoder_test.exs:411: anonymous fn/1 in Avrora.EncoderTest."test when decoding plain message that starts with what looks like a magic byte"/1
       (avrora 0.17.0) lib/avrora/resolver.ex:47: Avrora.Resolver.resolve/1
       (avrora 0.17.0) lib/avrora/resolver.ex:26: anonymous fn/1 in Avrora.Resolver.resolve_any/1
       (elixir 1.10.4) lib/stream.ex:572: anonymous fn/4 in Stream.map/2
       (elixir 1.10.4) lib/enum.ex:3686: Enumerable.List.reduce/3
       (elixir 1.10.4) lib/stream.ex:1609: Enumerable.Stream.do_each/4
       (elixir 1.10.4) lib/enum.ex:1027: Enum.find_value/3
       (avrora 0.17.0) lib/avrora/codec/schema_registry.ex:57: Avrora.Codec.SchemaRegistry.decode/2
       test/avrora/encoder_test.exs:437: (test)
```