### PR TITLE
Make private clients schema_path work better for releases

### DIFF
--- a/lib/avrora/client.ex
+++ b/lib/avrora/client.ex
@@ -98,7 +98,13 @@ defmodule Avrora.Client do
 
           import Keyword, only: [get: 3]
 
-          def schemas_path, do: get(@opts, :schemas_path, Path.expand("./priv/schemas"))
+          def schemas_path do
+            case get(@opts, :schemas_path, Path.expand("./priv/schemas")) do
+              {app, path} -> Application.app_dir(app, path)
+              path -> path
+            end
+          end
+          
           def registry_url, do: get(@opts, :registry_url, nil)
           def registry_auth, do: get(@opts, :registry_url, nil)
           def registry_schemas_autoreg, do: get(@opts, :registry_schemas_autoreg, true)


### PR DESCRIPTION
Hardcoding a path to schemas at compile time doesn't work well when using releases. This change would allow for the following notation (used by many elixir libraries e.g. see Plug.Static) `schemas_path: {:my_app, "priv/schemas"}`, which is then at runtime converted to the proper path. 