### PR TITLE
Fix registry_auth to return the proper variable

### DIFF
--- a/lib/avrora/client.ex
+++ b/lib/avrora/client.ex
@@ -100,7 +100,7 @@ defmodule Avrora.Client do
 
           def schemas_path, do: get(@opts, :schemas_path, Path.expand("./priv/schemas"))
           def registry_url, do: get(@opts, :registry_url, nil)
-          def registry_auth, do: get(@opts, :registry_url, nil)
+          def registry_auth, do: get(@opts, :registry_auth, nil)
           def registry_schemas_autoreg, do: get(@opts, :registry_schemas_autoreg, true)
           def convert_null_values, do: get(@opts, :convert_null_values, true)
           def convert_map_to_proplist, do: get(@opts, :convert_map_to_proplist, false)


### PR DESCRIPTION
You accidentally put `registry_url` as the return variable of the `registry_auth/0` function in this PR: https://github.com/Strech/avrora/pull/83/files#diff-d3c854ddf22006a09e725337d6c026d9cbe41454684022231fb56238a665047bR103

This is causing the error `** (CaseClauseError) no case clause matching:`