### PR TITLE
Increment erlavro to avoid rebar2 issue.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -110,7 +110,7 @@ defmodule Avrora.MixProject do
   defp deps do
     [
       {:jason, "~> 1.0"},
-      {:erlavro, "~> 2.9.3"},
+      {:erlavro, "~> 2.9.8"},
       {:credo, "~> 1.5", only: :dev, runtime: false},
       {:ex_doc, "~> 0.24", only: :dev, runtime: false},
       {:dialyxir, "~> 1.1", only: :dev, runtime: false},


### PR DESCRIPTION
erlavro 2.9.8 is no longer dependent upon Rebar2 (which will cause deprecation warnings).