### PR TITLE
Add user-agent header when calling registry 

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ defmodule MyClient do
     convert_null_values: false,
     convert_map_to_proplist: false,
     names_cache_ttl: :timer.minutes(5),
+    user_agent_header: "@strech/avrora",
     decoder_hook: &MyClient.decoder_hook/4
 end
 ```
@@ -109,6 +110,7 @@ config :avrora,
   convert_null_values: false, # optional: if you want to keep decoded `:null` values as is
   convert_map_to_proplist: false, # optional: if you want to restore the old behavior for decoding map-type
   names_cache_ttl: :timer.minutes(5), # optional: if you want periodic disk reads
+  user_agent_header: "@strech/avrora", # optional
   decoder_hook: &MyClient.decoder_hook/4 # optional: if you want to amend the data/result
 ```
 
@@ -120,6 +122,7 @@ config :avrora,
 - `convert_null_values`<sup>[v0.14]</sup> - Flag for automatic conversion of decoded `:null` values into `nil`, default `true`
 - `convert_map_to_proplist`<sup>[v0.15]</sup> restore old behaviour and confiugre decoding map-type to proplist, default `false`
 - `names_cache_ttl`<sup>[v0.10]</sup> - Time in ms to cache schemas by name in memory, default `:infinity`
+- `user_agent_header` - Adding user-agent to the request, default `@strech/avrora`
 - `decoder_hook`<sup>[v0.24]</sup> - Function with arity 4 to amend data or result, default `fn _, _, data, fun -> fun.(data) end`
 
 Set `names_cache_ttl` to `:infinity` will cache forever (no more disk reads will

--- a/config/config.exs
+++ b/config/config.exs
@@ -6,6 +6,7 @@ config :avrora,
   registry_auth: nil,
   registry_schemas_autoreg: true,
   convert_null_values: true,
-  names_cache_ttl: :infinity
+  names_cache_ttl: :infinity,
+  user_agent_header: nil
 
 config :logger, :console, format: "$time $metadata[$level] $levelpad$message\n"

--- a/lib/avrora/client.ex
+++ b/lib/avrora/client.ex
@@ -115,6 +115,7 @@ defmodule Avrora.Client do
           def convert_null_values, do: get(@opts, :convert_null_values, true)
           def convert_map_to_proplist, do: get(@opts, :convert_map_to_proplist, false)
           def names_cache_ttl, do: get(@opts, :names_cache_ttl, :infinity)
+          def user_agent_header, do: get(@opts, :user_agent_header, nil)
           def decoder_hook, do: get(@opts, :decoder_hook, fn _, _, data, fun -> fun.(data) end)
           def file_storage, do: unquote(:"Elixir.#{module}.Storage.File")
           def memory_storage, do: unquote(:"Elixir.#{module}.Storage.Memory")

--- a/lib/avrora/config.ex
+++ b/lib/avrora/config.ex
@@ -12,6 +12,7 @@ defmodule Avrora.Config do
       * `convert_null_values` convert `:null` values in the decoded message into `nil`, default `true`
       * `convert_map_to_proplist` bring back old behavior and configure decoding AVRO map-type as proplist, default `false`
       * `names_cache_ttl` duration to cache global schema names millisecods, default `:infinity`
+      * `user_agent_header` adding user-agent to the request, default `@strech/avrora`
       * `decoder_hook` function to amend decoded payload, default `fn _, _, data, fun -> fun.(data) end`
 
   ## Internal use interface:
@@ -30,6 +31,7 @@ defmodule Avrora.Config do
   @callback convert_null_values :: boolean()
   @callback convert_map_to_proplist :: boolean()
   @callback names_cache_ttl :: integer() | atom()
+  @callback user_agent_header :: String.t() | nil
   @callback decoder_hook :: (any(), any(), any(), any() -> any())
   @callback file_storage :: module()
   @callback memory_storage :: module()
@@ -62,6 +64,9 @@ defmodule Avrora.Config do
 
   @doc false
   def names_cache_ttl, do: get_env(:names_cache_ttl, :infinity)
+
+  @doc false
+  def user_agent_header, do: get_env(:user_agent_header, nil)
 
   @doc false
   def decoder_hook, do: get_env(:decoder_hook, fn _, _, data, fun -> fun.(data) end)

--- a/lib/avrora/http_client.ex
+++ b/lib/avrora/http_client.ex
@@ -28,10 +28,15 @@ defmodule Avrora.HTTPClient do
   end
 
   defp extract_headers(options) do
-    case Keyword.get(options, :authorization) do
-      nil -> {:ok, []}
-      credentials -> {:ok, [{'Authorization', '#{credentials}'}]}
-    end
+    credentials =
+      case Keyword.get(options, :authorization) do
+        nil -> []
+        credentials -> [{'Authorization', '#{credentials}'}]
+      end
+
+    user_agent = [{'User-Agent', '#{Keyword.get(options, :user_agent)}'}]
+
+    {:ok, credentials ++ user_agent}
   end
 
   defp handle(200 = _status, body), do: Jason.decode(body)

--- a/lib/avrora/storage/registry.ex
+++ b/lib/avrora/storage/registry.ex
@@ -15,6 +15,7 @@ defmodule Avrora.Storage.Registry do
 
   @behaviour Avrora.Storage
   @content_type "application/vnd.schemaregistry.v1+json"
+  @user_agent "@strech/avrora"
 
   @doc """
   Get schema by integer ID or by the subject name.
@@ -131,14 +132,19 @@ defmodule Avrora.Storage.Registry do
 
   # NOTE: Maybe move to compile-time?
   defp headers do
-    case registry_auth() do
-      {:basic, [username, password]} ->
-        credentials = :base64.encode("#{username}:#{password}")
-        [authorization: "Basic #{credentials}"]
+    auth =
+      case registry_auth() do
+        {:basic, [username, password]} ->
+          credentials = :base64.encode("#{username}:#{password}")
+          [authorization: "Basic #{credentials}"]
 
-      nil ->
-        []
-    end
+        nil ->
+          []
+      end
+
+    user_agent = [user_agent: user_agent_header() || @user_agent]
+
+    auth ++ user_agent
   end
 
   defp to_url(path), do: "#{registry_url()}/#{path}"
@@ -162,4 +168,5 @@ defmodule Avrora.Storage.Registry do
   defp http_client, do: Config.self().http_client()
   defp registry_url, do: Config.self().registry_url()
   defp registry_auth, do: Config.self().registry_auth()
+  defp user_agent_header, do: Config.self().user_agent_header()
 end

--- a/test/avrora/storage/registry_test.exs
+++ b/test/avrora/storage/registry_test.exs
@@ -20,7 +20,7 @@ defmodule Avrora.Storage.RegistryTest do
       Avrora.HTTPClientMock
       |> expect(:get, fn url, options ->
         assert url == "http://reg.loc/subjects/io.confluent.Account/versions/latest"
-        assert options == []
+        assert options == [{:user_agent, "@strech/avrora"}]
 
         {
           :ok,
@@ -39,7 +39,7 @@ defmodule Avrora.Storage.RegistryTest do
       Avrora.HTTPClientMock
       |> expect(:get, fn url, options ->
         assert url == "http://reg.loc/subjects/io.confluent.User/versions/1"
-        assert options == []
+        assert options == [{:user_agent, "@strech/avrora"}]
 
         {
           :ok,
@@ -64,7 +64,7 @@ defmodule Avrora.Storage.RegistryTest do
       Avrora.HTTPClientMock
       |> expect(:get, fn url, options ->
         assert url == "http://reg.loc/subjects/io.confluent.Account/versions/latest"
-        assert options == []
+        assert options == [{:user_agent, "@strech/avrora"}]
 
         {
           :ok,
@@ -86,7 +86,7 @@ defmodule Avrora.Storage.RegistryTest do
       Avrora.HTTPClientMock
       |> expect(:get, fn url, options ->
         assert url == "http://reg.loc/subjects/io.confluent.Unexisting/versions/latest"
-        assert options == []
+        assert options == [{:user_agent, "@strech/avrora"}]
 
         {:error, subject_not_found_parsed_error()}
       end)
@@ -98,7 +98,7 @@ defmodule Avrora.Storage.RegistryTest do
       Avrora.HTTPClientMock
       |> expect(:get, fn url, options ->
         assert url == "http://reg.loc/subjects/io.confluent.Payment/versions/latest"
-        assert options == []
+        assert options == [{:user_agent, "@strech/avrora"}]
 
         {
           :ok,
@@ -122,7 +122,7 @@ defmodule Avrora.Storage.RegistryTest do
       Avrora.HTTPClientMock
       |> expect(:get, fn url, options ->
         assert url == "http://reg.loc/subjects/io.confluent.Payment/versions/10"
-        assert options == []
+        assert options == [{:user_agent, "@strech/avrora"}]
 
         {
           :ok,
@@ -146,7 +146,7 @@ defmodule Avrora.Storage.RegistryTest do
       Avrora.HTTPClientMock
       |> expect(:get, fn url, options ->
         assert url == "http://reg.loc/subjects/io.confluent.Payment/versions/latest"
-        assert options == []
+        assert options == [{:user_agent, "@strech/avrora"}]
 
         {:error, subject_not_found_parsed_error()}
       end)
@@ -158,7 +158,7 @@ defmodule Avrora.Storage.RegistryTest do
       Avrora.HTTPClientMock
       |> expect(:get, fn url, options ->
         assert url == "http://reg.loc/schemas/ids/1"
-        assert options == []
+        assert options == [{:user_agent, "@strech/avrora"}]
 
         {:ok, %{"schema" => json_schema()}}
       end)
@@ -176,7 +176,7 @@ defmodule Avrora.Storage.RegistryTest do
       Avrora.HTTPClientMock
       |> expect(:get, fn url, options ->
         assert url == "http://reg.loc/schemas/ids/1"
-        assert options == [authorization: "Basic bG9naW46cGFzc3dvcmQ="]
+        assert options == [authorization: "Basic bG9naW46cGFzc3dvcmQ=", user_agent: "@strech/avrora"]
 
         {:ok, %{"schema" => json_schema()}}
       end)
@@ -192,7 +192,7 @@ defmodule Avrora.Storage.RegistryTest do
       Avrora.HTTPClientMock
       |> expect(:get, fn url, options ->
         assert url == "http://reg.loc/schemas/ids/1"
-        assert options == []
+        assert options == [{:user_agent, "@strech/avrora"}]
 
         {:error, version_not_found_parsed_error()}
       end)
@@ -204,7 +204,7 @@ defmodule Avrora.Storage.RegistryTest do
       Avrora.HTTPClientMock
       |> expect(:get, fn url, options ->
         assert url == "http://reg.loc/schemas/ids/43"
-        assert options == []
+        assert options == [{:user_agent, "@strech/avrora"}]
 
         {
           :ok,
@@ -223,7 +223,7 @@ defmodule Avrora.Storage.RegistryTest do
       Avrora.HTTPClientMock
       |> expect(:get, fn url, options ->
         assert url == "http://reg.loc/subjects/io.confluent.User/versions/1"
-        assert options == []
+        assert options == [{:user_agent, "@strech/avrora"}]
 
         {
           :ok,
@@ -257,7 +257,7 @@ defmodule Avrora.Storage.RegistryTest do
       |> expect(:post, fn url, payload, options ->
         assert url == "http://reg.loc/subjects/io.confluent.Payment/versions"
         assert payload == json_schema()
-        assert options == [content_type: "application/vnd.schemaregistry.v1+json"]
+        assert options == [content_type: "application/vnd.schemaregistry.v1+json", user_agent: "@strech/avrora"]
 
         {:ok, %{"id" => 1}}
       end)
@@ -279,7 +279,8 @@ defmodule Avrora.Storage.RegistryTest do
 
         assert options == [
                  content_type: "application/vnd.schemaregistry.v1+json",
-                 authorization: "Basic bG9naW46cGFzc3dvcmQ="
+                 authorization: "Basic bG9naW46cGFzc3dvcmQ=",
+                 user_agent: "@strech/avrora"
                ]
 
         {:ok, %{"id" => 1}}

--- a/test/support/config.ex
+++ b/test/support/config.ex
@@ -46,6 +46,8 @@ defmodule Support.Config do
   @impl true
   def names_cache_ttl, do: :infinity
   @impl true
+  def user_agent_header, do: nil
+  @impl true
   def decoder_hook, do: fn _, _, data, fun -> fun.(data) end
   @impl true
   def convert_map_to_proplist, do: false


### PR DESCRIPTION
**Background**
AWS WAF's core managed rule group contains a rule that rejects requests missing a user-agent header. If the schema registry on AWS behind a WAF with this rule group, which blocks all requests. To avoid this, we should set a user agent in the HTTP header. 

Reference: 
 - [Use AWS Managed Rules to prevent common attacks](https://aws.amazon.com/premiumsupport/knowledge-center/waf-block-common-attacks/) 
  - [kafkajs/confluent-schema-registry](https://github.com/kafkajs/confluent-schema-registry/blob/a3921d3cbd203eb7c41a0cb321b12a2608c7ecd8/src/api/middleware/userAgent.ts#L10)


