### PR TITLE
Load app config when `--module` arg is used

### DIFF
--- a/lib/mix/tasks/avrora.reg.schema.ex
+++ b/lib/mix/tasks/avrora.reg.schema.ex
@@ -15,7 +15,8 @@ defmodule Mix.Tasks.Avrora.Reg.Schema do
     * `--name` - the full name of the schema to register (exclusive with `--all`)
     * `--as` - the name which will be used to register schema (i.e subject)
     * `--all` - register all found schemas
-    * `--module` - private Avrora client module (i.e MyClient)
+    * `--module` - the private Avrora client module (i.e MyClient)
+    * `--appconfig` - the app config file name to load from `config/` folder (i.e runtime)
 
   The `--module` option allows to use your private Avrora client module instead of
   the default `Avrora`.
@@ -25,6 +26,9 @@ defmodule Mix.Tasks.Avrora.Reg.Schema do
   The `--name` option expects that given schema name will comply to
   `Avrora.Storage.File` module rules.
 
+  The `--appconfig` option expects just application config file name without an extension
+  and will load it additionally to default. Note: runtime config doesn't support imports!
+
   For example, if the schema name is `io.confluent.Payment` it should be stored
   as `<schemas path>/io/confluent/Payment.avsc`
 
@@ -32,6 +36,7 @@ defmodule Mix.Tasks.Avrora.Reg.Schema do
 
       mix avrora.reg.schema --name io.confluent.Payment
       mix avrora.reg.schema --name io.confluent.Payment --as MyCustomName
+      mix avrora.reg.schema --all --appconfig runtime
       mix avrora.reg.schema --all --module MyClient
       mix avrora.reg.schema --all
   """
@@ -44,7 +49,8 @@ defmodule Mix.Tasks.Avrora.Reg.Schema do
       as: :string,
       all: :boolean,
       name: :string,
-      module: :string
+      module: :string,
+      appconfig: :string
     ]
   ]
 
@@ -53,23 +59,24 @@ defmodule Mix.Tasks.Avrora.Reg.Schema do
     Tasks.Loadpaths.run(["--no-elixir-version-check", "--no-archives-check"])
 
     {opts, _, _} = OptionParser.parse(argv, @cli_options)
-
-    {module_name, opts} =
-      case Keyword.pop(opts, :module) do
-        {nil, opts} ->
-          {:ok, _} = Application.ensure_all_started(:avrora)
-          {"Avrora", opts}
-
-        res ->
-          :ok = Mix.Task.run("app.config")
-          res
-      end
+    {module_name, opts} = Keyword.pop(opts, :module, "Avrora")
+    {app_config, opts} = Keyword.pop(opts, :appconfig)
 
     module = Module.concat(Elixir, String.trim(module_name))
     config = Module.concat(module, Config)
     registrar = Module.concat(module, Utils.Registrar)
 
+    {:ok, _} = Application.ensure_all_started(:avrora)
     {:ok, _} = module.start_link()
+
+    unless is_nil(app_config) do
+      Mix.Project.config()
+      |> Keyword.get(:config_path)
+      |> Path.dirname()
+      |> Path.join("#{app_config}.exs")
+      |> List.wrap()
+      |> Tasks.Loadconfig.run()
+    end
 
     case opts |> Keyword.keys() |> Enum.sort() do
       [:all] ->

--- a/lib/mix/tasks/avrora.reg.schema.ex
+++ b/lib/mix/tasks/avrora.reg.schema.ex
@@ -53,13 +53,22 @@ defmodule Mix.Tasks.Avrora.Reg.Schema do
     Tasks.Loadpaths.run(["--no-elixir-version-check", "--no-archives-check"])
 
     {opts, _, _} = OptionParser.parse(argv, @cli_options)
-    {module_name, opts} = Keyword.pop(opts, :module, "Avrora")
+
+    {module_name, opts} =
+      case Keyword.pop(opts, :module) do
+        {nil, opts} ->
+          {:ok, _} = Application.ensure_all_started(:avrora)
+          {"Avrora", opts}
+
+        res ->
+          :ok = Mix.Task.run("app.config")
+          res
+      end
 
     module = Module.concat(Elixir, String.trim(module_name))
     config = Module.concat(module, Config)
     registrar = Module.concat(module, Utils.Registrar)
 
-    {:ok, _} = Application.ensure_all_started(:avrora)
     {:ok, _} = module.start_link()
 
     case opts |> Keyword.keys() |> Enum.sort() do


### PR DESCRIPTION
Hello! I'm having troubles with `mix avrora.reg.schema` when I use the `--module` argument and my avrora client is configured with a `runtime.exs`.

I'll try to illustrate the problem, I have an avrora client like this one:

```elixir
defmodule MyApp.Avrora do
  use Avrora.Client, otp_app: :my_app
end
```

and I'm using a `runtime.exs`

```elixir
import Config

config :my_app, MyApp.Avrora,
  registry_url: System.fetch_env!("SCHEMA_REGISTRY_URL"),
  registry_auth:
    {:basic,
     [
       System.fetch_env!("SCHEMA_REGISTRY_USER"),
       System.fetch_env!("SCHEMA_REGISTRY_PASS")
     ]}
```

now the problem is that `my_app` is not being loaded by `mix avrora.reg.schema --all --module MyApp.Avrora`, so I get the following:

```
schema `my.namespace.SomeEvent' will be skipped due to an error `unconfigured_registry_url'
```

due to [`Application.get_env/3`](https://github.com/Strech/avrora/blob/7c165761e07b4042a574b0f1dfd77ffc8a29b60c/lib/avrora/client.ex#L133) returning `nil` when called with `:registry_url` key.

It looks like this could be solved by running `Mix.Task.run("app.config")` when `--module` command line argument is used (which I believe is not helpful otherwise).

cheers : )