### PR TITLE
Allow encode/2 to receive opts in any order

### DIFF
--- a/lib/avrora/encoder.ex
+++ b/lib/avrora/encoder.ex
@@ -105,6 +105,9 @@ defmodule Avrora.Encoder do
     end
   end
 
+  @type encode_opt :: {:schema_name, String.t()} | {:format, :guess | :registry | :ocf | :plain}
+  @type encode_opts :: [encode_opt()]
+
   @doc """
   Encode message map in Avro format, loading schema from local file or Schema Registry.
 
@@ -126,8 +129,7 @@ defmodule Avrora.Encoder do
             48, 48, 48, 48, 45, 48, 48, 48, 48, 45, 48, 48, 48, 48, 48, 48, 48, 48, 48,
             48, 48, 48, 123, 20, 174, 71, 225, 250, 47, 64>>}
   """
-  @spec encode(map(), schema_name: String.t(), format: :guess | :registry | :ocf | :plain) ::
-          {:ok, binary()} | {:error, term()}
+  @spec encode(map(), encode_opts()) :: {:ok, binary()} | {:error, term()}
   def encode(payload, opts) when is_map(payload) do
     schema_name = Keyword.fetch!(opts, :schema_name)
     format = Keyword.get(opts, :format, :guess)

--- a/lib/avrora/encoder.ex
+++ b/lib/avrora/encoder.ex
@@ -128,10 +128,10 @@ defmodule Avrora.Encoder do
   """
   @spec encode(map(), schema_name: String.t(), format: :guess | :registry | :ocf | :plain) ::
           {:ok, binary()} | {:error, term()}
-  def encode(payload, schema_name: schema_name) when is_map(payload),
-    do: encode(payload, schema_name: schema_name, format: :guess)
+  def encode(payload, opts) when is_map(payload) do
+    schema_name = Keyword.fetch!(opts, :schema_name)
+    format = Keyword.get(opts, :format, :guess)
 
-  def encode(payload, schema_name: schema_name, format: format) when is_map(payload) do
     with {:ok, schema_name} <- Name.parse(schema_name) do
       if format == :plain do
         Logger.warning(

--- a/lib/avrora/encoder.ex
+++ b/lib/avrora/encoder.ex
@@ -105,8 +105,11 @@ defmodule Avrora.Encoder do
     end
   end
 
-  @type encode_opt :: {:schema_name, String.t()} | {:format, :guess | :registry | :ocf | :plain}
-  @type encode_opts :: [encode_opt()]
+  def encode(payload, schema_name: schema_name) when is_map(payload),
+    do: encode(payload, schema_name: schema_name, format: :guess)
+
+  def encode(payload, format: format, schema_name: schema_name) when is_map(payload),
+    do: encode(payload, schema_name: schema_name, format: format)
 
   @doc """
   Encode message map in Avro format, loading schema from local file or Schema Registry.
@@ -129,11 +132,9 @@ defmodule Avrora.Encoder do
             48, 48, 48, 48, 45, 48, 48, 48, 48, 45, 48, 48, 48, 48, 48, 48, 48, 48, 48,
             48, 48, 48, 123, 20, 174, 71, 225, 250, 47, 64>>}
   """
-  @spec encode(map(), encode_opts()) :: {:ok, binary()} | {:error, term()}
-  def encode(payload, opts) when is_map(payload) do
-    schema_name = Keyword.fetch!(opts, :schema_name)
-    format = Keyword.get(opts, :format, :guess)
-
+  @spec encode(map(), schema_name: String.t(), format: :guess | :registry | :ocf | :plain) ::
+          {:ok, binary()} | {:error, term()}
+  def encode(payload, schema_name: schema_name, format: format) when is_map(payload) do
     with {:ok, schema_name} <- Name.parse(schema_name) do
       if format == :plain do
         Logger.warning(

--- a/test/avrora/encoder_test.exs
+++ b/test/avrora/encoder_test.exs
@@ -626,7 +626,7 @@ defmodule Avrora.EncoderTest do
       assert encoded == messenger_plain_message()
     end
 
-    test "it accepts `format:` option before `schema_name:`" do
+    test "when `format` passed before `schema_name` option it accepts the order" do
       messenger_schema = messenger_schema()
 
       Avrora.Storage.MemoryMock


### PR DESCRIPTION
The usual understanding, when a function accepts a keyword list as a last "options" argument, is that those options can be given in any order. On the other side, the current code pattern matches the list in exact order, so this expectation is not fulfilled, and this code raises a `FunctionClauseError`:

```ex
Avrora.encode(payload, format: :plain, schema_name: "io.confluent.Messenger")
```

This PR switches out the pattern matching on options, and uses appropriate `Keyword` functions to extract the values.

