### PR TITLE
fix: check for nil before expanding path

### DIFF
--- a/lib/avrora/client.ex
+++ b/lib/avrora/client.ex
@@ -131,9 +131,9 @@ defmodule Avrora.Client do
             def schemas_path, do: Application.app_dir(@otp_app, get(@opts, :schemas_path, "./priv/schemas"))
 
             def registry_ssl_cacert_path do
-              if path = get(@opts, :registry_ssl_cacert_path, nil) do
-                Path.expand(path)
-              end
+              path = get(@opts, :registry_ssl_cacert_path, nil)
+
+              if is_nil(path), do: nil, else: Path.expand(path)
             end
 
             defp get(opts, key, default) do

--- a/lib/avrora/client.ex
+++ b/lib/avrora/client.ex
@@ -129,7 +129,12 @@ defmodule Avrora.Client do
           else
             def self, do: get(@opts, :config, __MODULE__)
             def schemas_path, do: Application.app_dir(@otp_app, get(@opts, :schemas_path, "./priv/schemas"))
-            def registry_ssl_cacert_path, do: Path.expand(get(@opts, :registry_ssl_cacert_path, nil))
+
+            def registry_ssl_cacert_path do
+              if path = get(@opts, :registry_ssl_cacert_path, nil) do
+                Path.expand(path)
+              end
+            end
 
             defp get(opts, key, default) do
               app_opts = Application.get_env(@otp_app, unquote(:"Elixir.#{module}"), [])

--- a/test/avrora/client_test.exs
+++ b/test/avrora/client_test.exs
@@ -61,5 +61,9 @@ defmodule Avrora.ClientTest do
 
       assert Beta.Config.names_cache_ttl() == :infinity
     end
+
+    test "when otp_app is set and registry_ssl_cacert_path is not set" do
+      assert Gamma.Config.registry_ssl_cacert_path() == nil
+    end
   end
 end


### PR DESCRIPTION
This fixes an issue introduced in 0.29.0.