### PR TITLE
Change `is_decodable/1` to `decodable?/1`

### DIFF
--- a/lib/avrora/codec.ex
+++ b/lib/avrora/codec.ex
@@ -10,10 +10,18 @@ defmodule Avrora.Codec do
 
   ## Examples
 
-      ...> Avrora.Codec.Plain.is_decodable(<<1, 2, 3>>)
+      ...> Avrora.Codec.Plain.decodable?(<<1, 2, 3>>)
       true
-      ...> Avrora.Codec.SchemaRegistry.is_decodable(<<1, 2, 3>>)
+      ...> Avrora.Codec.SchemaRegistry.decodable?(<<1, 2, 3>>)
       false
+  """
+  @callback decodable?(payload :: binary()) :: boolean
+
+  @doc """
+  Checks whether a given binary Avro message is decodable with the Plain codec.
+
+  This function is deprecated and will be removed in future release. 
+  Please use `Avrora.Codec.Plain.decodable?/1` instead.   
   """
   @callback is_decodable(payload :: binary()) :: boolean
 

--- a/lib/avrora/codec.ex
+++ b/lib/avrora/codec.ex
@@ -17,12 +17,7 @@ defmodule Avrora.Codec do
   """
   @callback decodable?(payload :: binary()) :: boolean
 
-  @doc """
-  Checks whether a given binary Avro message is decodable with the Plain codec.
-
-  This function is deprecated and will be removed in future release. 
-  Please use `Avrora.Codec.Plain.decodable?/1` instead.   
-  """
+  @doc deprecated: "Use `Avrora.Codec.Plain.decodable?/1` instead."
   @callback is_decodable(payload :: binary()) :: boolean
 
   @doc """

--- a/lib/avrora/codec/object_container_file.ex
+++ b/lib/avrora/codec/object_container_file.ex
@@ -20,6 +20,14 @@ defmodule Avrora.Codec.ObjectContainerFile do
   alias Avrora.Schema.Encoder, as: SchemaEncoder
 
   @impl true
+  def decodable?(payload) when is_binary(payload) do
+    case payload do
+      <<@magic_bytes, _::binary>> -> true
+      _ -> false
+    end
+  end
+
+  @impl true
   def is_decodable(payload) when is_binary(payload) do
     case payload do
       <<@magic_bytes, _::binary>> -> true

--- a/lib/avrora/codec/object_container_file.ex
+++ b/lib/avrora/codec/object_container_file.ex
@@ -33,10 +33,7 @@ defmodule Avrora.Codec.ObjectContainerFile do
       "`Avrora.Codec.ObjectContainerFile.is_decodable/1` is deprecated, use `Avrora.Codec.ObjectContainerFile.decodable?/1` instead"
     )
 
-    case payload do
-      <<@magic_bytes, _::binary>> -> true
-      _ -> false
-    end
+    decodable?(payload)
   end
 
   @impl true

--- a/lib/avrora/codec/object_container_file.ex
+++ b/lib/avrora/codec/object_container_file.ex
@@ -29,6 +29,9 @@ defmodule Avrora.Codec.ObjectContainerFile do
 
   @impl true
   def is_decodable(payload) when is_binary(payload) do
+    Logger.warning(
+      "`Avrora.Codec.ObjectContainerFile.is_decodable/1` is deprecated, use `Avrora.Codec.ObjectContainerFile.decodable?/1` instead"
+    )
     case payload do
       <<@magic_bytes, _::binary>> -> true
       _ -> false

--- a/lib/avrora/codec/object_container_file.ex
+++ b/lib/avrora/codec/object_container_file.ex
@@ -32,6 +32,7 @@ defmodule Avrora.Codec.ObjectContainerFile do
     Logger.warning(
       "`Avrora.Codec.ObjectContainerFile.is_decodable/1` is deprecated, use `Avrora.Codec.ObjectContainerFile.decodable?/1` instead"
     )
+
     case payload do
       <<@magic_bytes, _::binary>> -> true
       _ -> false

--- a/lib/avrora/codec/plain.ex
+++ b/lib/avrora/codec/plain.ex
@@ -8,6 +8,7 @@ defmodule Avrora.Codec.Plain do
 
   @behaviour Avrora.Codec
 
+  require Logger
   alias Avrora.AvroDecoderOptions
   alias Avrora.Resolver
 
@@ -15,7 +16,12 @@ defmodule Avrora.Codec.Plain do
   def decodable?(payload) when is_binary(payload), do: true
 
   @impl true
-  def is_decodable(payload) when is_binary(payload), do: true
+  def is_decodable(payload) when is_binary(payload) do
+    Logger.warning(
+      "`Avrora.Codec.Plain.is_decodable/1` is deprecated, use `Avrora.Codec.Plain.decodable?/1` instead"
+    )
+    true
+  end
 
   @impl true
   def extract_schema(_payload), do: {:error, :schema_not_found}

--- a/lib/avrora/codec/plain.ex
+++ b/lib/avrora/codec/plain.ex
@@ -12,6 +12,9 @@ defmodule Avrora.Codec.Plain do
   alias Avrora.Resolver
 
   @impl true
+  def decodable?(payload) when is_binary(payload), do: true
+
+  @impl true
   def is_decodable(payload) when is_binary(payload), do: true
 
   @impl true

--- a/lib/avrora/codec/plain.ex
+++ b/lib/avrora/codec/plain.ex
@@ -17,9 +17,8 @@ defmodule Avrora.Codec.Plain do
 
   @impl true
   def is_decodable(payload) when is_binary(payload) do
-    Logger.warning(
-      "`Avrora.Codec.Plain.is_decodable/1` is deprecated, use `Avrora.Codec.Plain.decodable?/1` instead"
-    )
+    Logger.warning("`Avrora.Codec.Plain.is_decodable/1` is deprecated, use `Avrora.Codec.Plain.decodable?/1` instead")
+
     true
   end
 

--- a/lib/avrora/codec/plain.ex
+++ b/lib/avrora/codec/plain.ex
@@ -19,7 +19,7 @@ defmodule Avrora.Codec.Plain do
   def is_decodable(payload) when is_binary(payload) do
     Logger.warning("`Avrora.Codec.Plain.is_decodable/1` is deprecated, use `Avrora.Codec.Plain.decodable?/1` instead")
 
-    true
+    decodable?(payload)
   end
 
   @impl true

--- a/lib/avrora/codec/schema_registry.ex
+++ b/lib/avrora/codec/schema_registry.ex
@@ -24,6 +24,9 @@ defmodule Avrora.Codec.SchemaRegistry do
 
   @impl true
   def is_decodable(payload) when is_binary(payload) do
+    Logger.warning(
+      "`Avrora.Codec.SchemaRegistry.is_decodable/1` is deprecated, use `Avrora.Codec.SchemaRegistry.decodable?/1` instead"
+    )
     case payload do
       <<@magic_bytes, _::binary>> -> true
       _ -> false

--- a/lib/avrora/codec/schema_registry.ex
+++ b/lib/avrora/codec/schema_registry.ex
@@ -27,6 +27,7 @@ defmodule Avrora.Codec.SchemaRegistry do
     Logger.warning(
       "`Avrora.Codec.SchemaRegistry.is_decodable/1` is deprecated, use `Avrora.Codec.SchemaRegistry.decodable?/1` instead"
     )
+
     case payload do
       <<@magic_bytes, _::binary>> -> true
       _ -> false

--- a/lib/avrora/codec/schema_registry.ex
+++ b/lib/avrora/codec/schema_registry.ex
@@ -28,10 +28,7 @@ defmodule Avrora.Codec.SchemaRegistry do
       "`Avrora.Codec.SchemaRegistry.is_decodable/1` is deprecated, use `Avrora.Codec.SchemaRegistry.decodable?/1` instead"
     )
 
-    case payload do
-      <<@magic_bytes, _::binary>> -> true
-      _ -> false
-    end
+    decodable?(payload)
   end
 
   @impl true

--- a/lib/avrora/codec/schema_registry.ex
+++ b/lib/avrora/codec/schema_registry.ex
@@ -15,6 +15,14 @@ defmodule Avrora.Codec.SchemaRegistry do
   alias Avrora.Schema
 
   @impl true
+  def decodable?(payload) when is_binary(payload) do
+    case payload do
+      <<@magic_bytes, _::binary>> -> true
+      _ -> false
+    end
+  end
+
+  @impl true
   def is_decodable(payload) when is_binary(payload) do
     case payload do
       <<@magic_bytes, _::binary>> -> true

--- a/lib/avrora/encoder.ex
+++ b/lib/avrora/encoder.ex
@@ -26,7 +26,7 @@ defmodule Avrora.Encoder do
   def extract_schema(payload) when is_binary(payload) do
     codec =
       [Codec.SchemaRegistry, Codec.ObjectContainerFile, Codec.Plain]
-      |> Enum.find(& &1.is_decodable(payload))
+      |> Enum.find(& &1.decodable?(payload))
 
     codec.extract_schema(payload)
   end
@@ -46,7 +46,7 @@ defmodule Avrora.Encoder do
   def decode(payload) when is_binary(payload) do
     codec =
       [Codec.SchemaRegistry, Codec.ObjectContainerFile, Codec.Plain]
-      |> Enum.find(& &1.is_decodable(payload))
+      |> Enum.find(& &1.decodable?(payload))
 
     codec.decode(payload)
   end
@@ -73,7 +73,7 @@ defmodule Avrora.Encoder do
 
       codec =
         [Codec.SchemaRegistry, Codec.ObjectContainerFile, Codec.Plain]
-        |> Enum.find(& &1.is_decodable(payload))
+        |> Enum.find(& &1.decodable?(payload))
 
       if codec == Codec.Plain do
         Logger.warning(

--- a/test/avrora/codec/object_container_file_test.exs
+++ b/test/avrora/codec/object_container_file_test.exs
@@ -11,13 +11,13 @@ defmodule Avrora.Codec.ObjectContainerFileTest do
   setup :verify_on_exit!
   setup :support_config
 
-  describe "is_decodable/1" do
+  describe "decodable?/1" do
     test "when payload is a valid binary" do
-      assert Codec.ObjectContainerFile.is_decodable(payment_message())
+      assert Codec.ObjectContainerFile.decodable?(payment_message())
     end
 
     test "when payload is not a valid binary" do
-      refute Codec.ObjectContainerFile.is_decodable(<<0, 1, 2>>)
+      refute Codec.ObjectContainerFile.decodable?(<<0, 1, 2>>)
     end
   end
 

--- a/test/avrora/codec/plain_test.exs
+++ b/test/avrora/codec/plain_test.exs
@@ -10,13 +10,13 @@ defmodule Avrora.Codec.PlainTest do
   setup :verify_on_exit!
   setup :support_config
 
-  describe "is_decodable/1" do
+  describe "decodable?/1" do
     test "when payload is a valid binary" do
-      assert Codec.Plain.is_decodable(payment_message())
+      assert Codec.Plain.decodable?(payment_message())
     end
 
     test "when payload is not a valid binary" do
-      assert Codec.Plain.is_decodable(<<0, 1, 2>>)
+      assert Codec.Plain.decodable?(<<0, 1, 2>>)
     end
   end
 

--- a/test/avrora/codec/schema_registry_test.exs
+++ b/test/avrora/codec/schema_registry_test.exs
@@ -11,13 +11,13 @@ defmodule Avrora.Codec.SchemaRegistryTest do
   setup :verify_on_exit!
   setup :support_config
 
-  describe "is_decodable/1" do
+  describe "decodable?/1" do
     test "when payload is a valid binary" do
-      assert Codec.SchemaRegistry.is_decodable(payment_message())
+      assert Codec.SchemaRegistry.decodable?(payment_message())
     end
 
     test "when payload is not a valid binary" do
-      assert Codec.SchemaRegistry.is_decodable(<<0, 1, 2>>)
+      assert Codec.SchemaRegistry.decodable?(<<0, 1, 2>>)
     end
   end
 


### PR DESCRIPTION
Addressing https://github.com/Strech/avrora/issues/132

**Summary** 
 - Deprecate is_decodable/1 and follow new naming convention  decodable?/1
 - Log a warning message when `is_decodable/1` is used.