### PR TITLE
Patch/Fix: `Avrora.HTTPClient.post/3` to guard the map instead of binary ( No longer receiving binary payload)

### DIFF
--- a/lib/avrora/http_client.ex
+++ b/lib/avrora/http_client.ex
@@ -19,7 +19,7 @@ defmodule Avrora.HTTPClient do
 
   @doc false
   @spec post(String.t(), term(), keyword(String.t())) :: {:ok, map()} | {:error, term()}
-  def post(url, payload, options \\ []) when is_binary(payload) do
+  def post(url, payload, options \\ []) when is_map(payload) do
     with {:ok, body} <- Jason.encode(payload),
          {:ok, content_type} <- Keyword.fetch(options, :content_type),
          {:ok, headers} <- extract_headers(options),


### PR DESCRIPTION
**Addressing Bug that introduced in `0.29.0`** 
Issue:  https://github.com/Strech/avrora/issues/135